### PR TITLE
Additional options for SSL certificate verification

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -410,14 +410,16 @@ extern "C" void evma_start_tls (const unsigned long binding)
 
 /******************
 evma_set_tls_parms
+	* [MH] Added ca_filename - an optional certificate authority file provided to SSL_CTX_load_verify_locations for client-side server certificate verification using this list of known trusted CAs
+	* [MH] Added privatekey_pwd - an optional password used to decrypt the privatekey_filename
 ******************/
 
-extern "C" void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filename, int verify_peer)
+extern "C" void evma_set_tls_parms (const unsigned long binding, const char *ca_filename, const char *privatekey_filename, const char *privatekey_pwd, const char *certchain_filename, int verify_peer)
 {
 	ensure_eventmachine("evma_set_tls_parms");
 	EventableDescriptor *ed = dynamic_cast <EventableDescriptor*> (Bindable_t::GetObject (binding));
 	if (ed)
-		ed->SetTlsParms (privatekey_filename, certchain_filename, (verify_peer == 1 ? true : false));
+		ed->SetTlsParms (ca_filename, privatekey_filename, privatekey_pwd, certchain_filename, (verify_peer == 1 ? true : false));
 }
 
 /******************

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1037,7 +1037,7 @@ void ConnectionDescriptor::StartTls()
 	if (SslBox)
 		throw std::runtime_error ("SSL/TLS already running on connection");
 
-	SslBox = new SslBox_t (bIsServer, PrivateKeyFilename, CertChainFilename, bSslVerifyPeer, GetBinding());
+	SslBox = new SslBox_t (bIsServer, CAFilename, PrivateKeyFilename, PrivateKeyPwd, CertChainFilename, bSslVerifyPeer, GetBinding());
 	_DispatchCiphertext();
 	#endif
 
@@ -1051,13 +1051,18 @@ void ConnectionDescriptor::StartTls()
 ConnectionDescriptor::SetTlsParms
 *********************************/
 
-void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer)
+void ConnectionDescriptor::SetTlsParms (const char *ca_filename, const char *privkey_filename, const char *privkey_pwd, const char *certchain_filename, bool verify_peer)
 {
 	#ifdef WITH_SSL
 	if (SslBox)
 		throw std::runtime_error ("call SetTlsParms before calling StartTls");
-	if (privkey_filename && *privkey_filename)
+	if (privkey_filename && *privkey_filename) {
 		PrivateKeyFilename = privkey_filename;
+		if (privkey_pwd && *privkey_pwd)
+			PrivateKeyPwd = privkey_pwd;
+	}
+	if (ca_filename && *ca_filename)
+		CAFilename = ca_filename;
 	if (certchain_filename && *certchain_filename)
 		CertChainFilename = certchain_filename;
 	bSslVerifyPeer = verify_peer;

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -69,7 +69,7 @@ class EventableDescriptor: public Bindable_t
 		virtual bool GetSubprocessPid (pid_t*) {return false;}
 
 		virtual void StartTls() {}
-		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer) {}
+		virtual void SetTlsParms (const char *ca_filename, const char *privkey_filename, const char *privkey_file_pwd, const char *certchain_filename, bool verify_peer) {}
 
 		#ifdef WITH_SSL
 		virtual X509 *GetPeerCert() {return NULL;}
@@ -182,7 +182,7 @@ class ConnectionDescriptor: public EventableDescriptor
 		virtual int GetOutboundDataSize() {return OutboundDataSize;}
 
 		virtual void StartTls();
-		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer);
+		virtual void SetTlsParms (const char *ca_filename, const char *privkey_filename, const char *privkey_pwd, const char *certchain_filename, bool verify_peer);
 
 		#ifdef WITH_SSL
 		virtual X509 *GetPeerCert();
@@ -225,7 +225,9 @@ class ConnectionDescriptor: public EventableDescriptor
 		#ifdef WITH_SSL
 		SslBox_t *SslBox;
 		std::string CertChainFilename;
+		std::string CAFilename;
 		std::string PrivateKeyFilename;
+		std::string PrivateKeyPwd;
 		bool bHandshakeSignaled;
 		bool bSslVerifyPeer;
 		bool bSslPeerAccepted;

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -63,7 +63,7 @@ extern "C" {
 	const unsigned long evma_create_unix_domain_server (const char *filename);
 	const unsigned long evma_open_datagram_socket (const char *server, int port);
 	const unsigned long evma_open_keyboard();
-	void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filenane, int verify_peer);
+	void evma_set_tls_parms (const unsigned long binding, const char *ca_filename, const char *privatekey_filename, const char *privatekey_pwd, const char *certchain_filenane, int verify_peer);
 	void evma_start_tls (const unsigned long binding);
 
 	#ifdef WITH_SSL

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -260,16 +260,19 @@ static VALUE t_start_tls (VALUE self, VALUE signature)
 
 /***************
 t_set_tls_parms
+	* [MH] Added cafile - an optional certificate authority file provided to SSL_CTX_load_verify_locations for client-side server certificate verification using this list of known trusted CAs
+	* [MH] Added privkeypwd - an optional password used to decrypt the privatekey_filename
+
 ***************/
 
-static VALUE t_set_tls_parms (VALUE self, VALUE signature, VALUE privkeyfile, VALUE certchainfile, VALUE verify_peer)
+static VALUE t_set_tls_parms (VALUE self, VALUE signature, VALUE cafile, VALUE privkeyfile, VALUE privkeypwd, VALUE certchainfile, VALUE verify_peer)
 {
 	/* set_tls_parms takes a series of positional arguments for specifying such things
 	 * as private keys and certificate chains.
 	 * It's expected that the parameter list will grow as we add more supported features.
 	 * ALL of these parameters are optional, and can be specified as empty or NULL strings.
 	 */
-	evma_set_tls_parms (NUM2ULONG (signature), StringValuePtr (privkeyfile), StringValuePtr (certchainfile), (verify_peer == Qtrue ? 1 : 0));
+	evma_set_tls_parms (NUM2ULONG (signature), StringValuePtr (cafile), StringValuePtr (privkeyfile), StringValuePtr (privkeypwd), StringValuePtr (certchainfile), (verify_peer == Qtrue ? 1 : 0));
 	return Qnil;
 }
 
@@ -1074,7 +1077,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "start_tcp_server", (VALUE(*)(...))t_start_server, 2);
 	rb_define_module_function (EmModule, "stop_tcp_server", (VALUE(*)(...))t_stop_server, 1);
 	rb_define_module_function (EmModule, "start_unix_server", (VALUE(*)(...))t_start_unix_server, 1);
-	rb_define_module_function (EmModule, "set_tls_parms", (VALUE(*)(...))t_set_tls_parms, 4);
+	rb_define_module_function (EmModule, "set_tls_parms", (VALUE(*)(...))t_set_tls_parms, 6);
 	rb_define_module_function (EmModule, "start_tls", (VALUE(*)(...))t_start_tls, 1);
 	rb_define_module_function (EmModule, "get_peer_cert", (VALUE(*)(...))t_get_peer_cert, 1);
 	rb_define_module_function (EmModule, "send_data", (VALUE(*)(...))t_send_data, 3);

--- a/ext/ssl.h
+++ b/ext/ssl.h
@@ -33,7 +33,7 @@ class SslContext_t
 class SslContext_t
 {
 	public:
-		SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile);
+		SslContext_t (bool is_server, const string &cafile, const string &privkeyfile, const string &privkeypwd, const string &certchainfile);
 		virtual ~SslContext_t();
 
 	private:
@@ -57,7 +57,7 @@ class SslBox_t
 class SslBox_t
 {
 	public:
-		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, const unsigned long binding);
+		SslBox_t (bool is_server, const string &cafile, const string &privkeyfile, const string &privkeypwd, const string &certchainfile, bool verify_peer, const unsigned long binding);
 		virtual ~SslBox_t();
 
 		int PutPlaintext (const char*, int);

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -256,6 +256,11 @@ module EventMachine
     # and other options to be used with this Connection object. Here are the currently-supported
     # options:
     #
+    # * :ca_file :
+    # takes a String, which is interpreted as the name of a readable file in the
+    # local filesystem. The file is expected to contain a chain of X509 certificates in
+    # PEM format
+    #
     # * :cert_chain_file :
     # takes a String, which is interpreted as the name of a readable file in the
     # local filesystem. The file is expected to contain a chain of X509 certificates in
@@ -265,6 +270,10 @@ module EventMachine
     # * :private_key_file :
     # takes a String, which is interpreted as the name of a readable file in the
     # local filesystem. The file must contain a private key in PEM format.
+    #
+    # * :private_key_pwd :
+    # takes a String, which is interpreted as the password for the private_key_file
+    # specified above. if no password is supplied the file is opened without one.
     #
     # * :verify_peer :
     # takes either true or false. Default is false. This indicates whether a server should request a
@@ -297,7 +306,7 @@ module EventMachine
     # behaved than the ones for raw chunks of memory.
     #
     def start_tls args={}
-      priv_key, cert_chain, verify_peer = args.values_at(:private_key_file, :cert_chain_file, :verify_peer)
+      ca_file, priv_key, priv_key_pwd, cert_chain, verify_peer = args.values_at(:ca_file, :private_key_file, :private_key_pwd, :cert_chain_file, :verify_peer)
 
       [priv_key, cert_chain].each do |file|
         next if file.nil? or file.empty?
@@ -305,7 +314,7 @@ module EventMachine
           "Could not find #{file} for start_tls" unless File.exists? file
       end
 
-      EventMachine::set_tls_parms(@signature, priv_key || '', cert_chain || '', verify_peer)
+      EventMachine::set_tls_parms(@signature, ca_file || '', priv_key || '', priv_key_pwd || '', cert_chain || '', verify_peer)
       EventMachine::start_tls @signature
     end
 


### PR DESCRIPTION
As part of the project I'm working on, I added a couple of extra options to eventmachine evma_set_tls_parms  for dealing with SSL certificate verification, to more easily allow our thin server to act as a client to a remote server over SSL. 

I added an optional private key file password parameter that can be used to unlock a password protected private key file.

I also added an optional ca certificate file parameter that can be used to register additional CAs with SSL_CTX_load_verify_locations. The remote server we connect to has a certificate issued by our company CA which is not in a standard trust hierarchy, and I thought with such relatively simply verification requirements it would be better to handle this internally within eventmachine, rather than pushing the logic up to ruby's verify_peer every time, just to do the same thing. Ruby's verify_peer method is still called in this case, but our server doesn't do any additional verification.

If the implementation of these changes is acceptable, I thought they might make a useful addition.

This is the first time I've played around with eventmachine so apologies if this isn't the right approach to solving this problem - any more elegent solutions would be welcome! but I suppose at the very least, this pull request is a good way to articulate what I'm trying to achieve, and find the right solution to it.

Any feedback/suggestions are greatly appreciated,

Mike
