### PR TITLE
VC6 compilation fix

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -242,7 +242,7 @@ void EventableDescriptor::_GenericInboundDispatch(const char *buf, int size)
 
 	if (ProxyTarget) {
 		if (BytesToProxy > 0) {
-			unsigned long proxied = std::min(BytesToProxy, (unsigned long) size);
+			unsigned long proxied = min(BytesToProxy, (unsigned long) size);
 			ProxyTarget->SendOutboundData(buf, proxied);
 			BytesToProxy -= proxied;
 			if (BytesToProxy == 0) {


### PR DESCRIPTION
Tiny issue which prevented successful compilation with MSVC6:

```
ed.cpp(245) : error C2589: '(' : illegal token on right side of '::'
ed.cpp(245) : error C2059: syntax error : '::'
```

The problem is, Windows defined min and max as macros, which breaks std::min(). There are several ways to fix this. The easiest, since "using namespace std;" is already specified, is to just remove the "std::" from ed.cpp.
