### PR TITLE
Truly cancel timers

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -107,10 +107,10 @@ extern "C" const unsigned long evma_install_oneshot_timer (int seconds)
 evma_uninstall_oneshot_timer
 **************************/
 
-extern "C" int evma_uninstall_oneshot_timer (const unsigned long binding)
+extern "C" void evma_uninstall_oneshot_timer (const unsigned long binding)
 {
 	ensure_eventmachine("evma_uninstall_oneshot_timer");
-	return EventMachine->UninstallOneshotTimer (binding) ? 1 : 0;
+	EventMachine->UninstallOneshotTimer (binding);
 }
 
 

--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -103,6 +103,17 @@ extern "C" const unsigned long evma_install_oneshot_timer (int seconds)
 }
 
 
+/**************************
+evma_uninstall_oneshot_timer
+**************************/
+
+extern "C" int evma_uninstall_oneshot_timer (const unsigned long binding)
+{
+	ensure_eventmachine("evma_uninstall_oneshot_timer");
+	return EventMachine->UninstallOneshotTimer (binding) ? 1 : 0;
+}
+
+
 /**********************
 evma_connect_to_server
 **********************/

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1021,6 +1021,7 @@ bool EventMachine_t::_RunTimers()
 			break;
 		if (EventCallback)
 			(*EventCallback) (0, EM_TIMER_FIRED, NULL, i->second.GetBinding());
+		TimerBindings.erase (i->second.GetBinding());
 		Timers.erase (i);
 	}
 	return true;
@@ -1062,10 +1063,30 @@ const unsigned long EventMachine_t::InstallOneshotTimer (int milliseconds)
 	Timer_t t;
 	#ifndef HAVE_MAKE_PAIR
 	multimap<uint64_t,Timer_t>::iterator i = Timers.insert (multimap<uint64_t,Timer_t>::value_type (fire_at, t));
+	TimerBindings.insert (map<unsigned long,uint64_t>::value_type (t.GetBinding(), fire_at));
 	#else
 	multimap<uint64_t,Timer_t>::iterator i = Timers.insert (make_pair (fire_at, t));
+	TimerBindings.insert (make_pair (t.GetBinding(), fire_at));
 	#endif
 	return i->second.GetBinding();
+}
+
+
+/***********************************
+EventMachine_t::UninstallOneshotTimer
+***********************************/
+
+const bool EventMachine_t::UninstallOneshotTimer (unsigned long binding)
+{
+	map<unsigned long,uint64_t>::iterator fire_at = TimerBindings.find(binding);
+	if (fire_at == TimerBindings.end()) {
+		return false;
+	}
+
+	Timers.erase (fire_at->second);
+	TimerBindings.erase (fire_at);
+
+	return true;
 }
 
 

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1076,17 +1076,14 @@ const unsigned long EventMachine_t::InstallOneshotTimer (int milliseconds)
 EventMachine_t::UninstallOneshotTimer
 ***********************************/
 
-bool EventMachine_t::UninstallOneshotTimer (const unsigned long binding)
+void EventMachine_t::UninstallOneshotTimer (const unsigned long binding)
 {
 	map<unsigned long,uint64_t>::iterator fire_at = TimerBindings.find(binding);
-	if (fire_at == TimerBindings.end()) {
-		return false;
-	}
+	if (fire_at == TimerBindings.end())
+		return;
 
 	Timers.erase (fire_at->second);
 	TimerBindings.erase (fire_at);
-
-	return true;
 }
 
 

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1076,7 +1076,7 @@ const unsigned long EventMachine_t::InstallOneshotTimer (int milliseconds)
 EventMachine_t::UninstallOneshotTimer
 ***********************************/
 
-const bool EventMachine_t::UninstallOneshotTimer (unsigned long binding)
+bool EventMachine_t::UninstallOneshotTimer (const unsigned long binding)
 {
 	map<unsigned long,uint64_t>::iterator fire_at = TimerBindings.find(binding);
 	if (fire_at == TimerBindings.end()) {

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1019,13 +1019,11 @@ bool EventMachine_t::_RunTimers()
 			break;
 		if (i->first > MyCurrentLoopTime)
 			break;
-		uint64_t fire_at = i->first;
 		const unsigned long binding = i->second.GetBinding();
 		if (EventCallback)
 			(*EventCallback) (0, EM_TIMER_FIRED, NULL, binding);
-		// Save fire_at and binding beforehand, the iterator might be invalid now
-		TimerBindings.erase (binding);
-		Timers.erase (fire_at);
+		// The iterator might be invalid now, uninstall checks for unknown timers
+		UninstallOneshotTimer(binding);
 	}
 	return true;
 }

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1019,10 +1019,13 @@ bool EventMachine_t::_RunTimers()
 			break;
 		if (i->first > MyCurrentLoopTime)
 			break;
+		uint64_t fire_at = i->first;
+		const unsigned long binding = i->second.GetBinding();
 		if (EventCallback)
-			(*EventCallback) (0, EM_TIMER_FIRED, NULL, i->second.GetBinding());
-		TimerBindings.erase (i->second.GetBinding());
-		Timers.erase (i);
+			(*EventCallback) (0, EM_TIMER_FIRED, NULL, binding);
+		// Save fire_at and binding beforehand, the iterator might be invalid now
+		TimerBindings.erase (binding);
+		Timers.erase (fire_at);
 	}
 	return true;
 }
@@ -1078,12 +1081,13 @@ EventMachine_t::UninstallOneshotTimer
 
 void EventMachine_t::UninstallOneshotTimer (const unsigned long binding)
 {
-	map<unsigned long,uint64_t>::iterator fire_at = TimerBindings.find(binding);
-	if (fire_at == TimerBindings.end())
+	map<unsigned long,uint64_t>::iterator i = TimerBindings.find(binding);
+	if (i == TimerBindings.end())
 		return;
 
-	Timers.erase (fire_at->second);
-	TimerBindings.erase (fire_at);
+	uint64_t fire_at = i->second;
+	TimerBindings.erase (i);
+	Timers.erase (fire_at);
 }
 
 

--- a/ext/em.h
+++ b/ext/em.h
@@ -79,7 +79,7 @@ class EventMachine_t
 		void ScheduleHalt();
 		void SignalLoopBreaker();
 		const unsigned long InstallOneshotTimer (int);
-		bool UninstallOneshotTimer (const unsigned long);
+		void UninstallOneshotTimer (const unsigned long);
 		const unsigned long ConnectToServer (const char *, int, const char *, int);
 		const unsigned long ConnectToUnixServer (const char *);
 

--- a/ext/em.h
+++ b/ext/em.h
@@ -79,7 +79,7 @@ class EventMachine_t
 		void ScheduleHalt();
 		void SignalLoopBreaker();
 		const unsigned long InstallOneshotTimer (int);
-		const bool UninstallOneshotTimer (unsigned long);
+		bool UninstallOneshotTimer (const unsigned long);
 		const unsigned long ConnectToServer (const char *, int, const char *, int);
 		const unsigned long ConnectToUnixServer (const char *);
 

--- a/ext/em.h
+++ b/ext/em.h
@@ -79,6 +79,7 @@ class EventMachine_t
 		void ScheduleHalt();
 		void SignalLoopBreaker();
 		const unsigned long InstallOneshotTimer (int);
+		const bool UninstallOneshotTimer (unsigned long);
 		const unsigned long ConnectToServer (const char *, int, const char *, int);
 		const unsigned long ConnectToUnixServer (const char *);
 
@@ -175,6 +176,7 @@ class EventMachine_t
 		};
 
 		multimap<uint64_t, Timer_t> Timers;
+		map<unsigned long, uint64_t> TimerBindings;
 		multimap<uint64_t, EventableDescriptor*> Heartbeats;
 		map<int, Bindable_t*> Files;
 		map<int, Bindable_t*> Pids;

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -44,6 +44,7 @@ extern "C" {
 	void evma_run_machine();
 	void evma_release_library();
 	const unsigned long evma_install_oneshot_timer (int seconds);
+	int evma_uninstall_oneshot_timer (const unsigned long binding);
 	const unsigned long evma_connect_to_server (const char *bind_addr, int bind_port, const char *server, int port);
 	const unsigned long evma_connect_to_unix_server (const char *server);
 

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -44,7 +44,7 @@ extern "C" {
 	void evma_run_machine();
 	void evma_release_library();
 	const unsigned long evma_install_oneshot_timer (int seconds);
-	int evma_uninstall_oneshot_timer (const unsigned long binding);
+	void evma_uninstall_oneshot_timer (const unsigned long binding);
 	const unsigned long evma_connect_to_server (const char *bind_addr, int bind_port, const char *server, int port);
 	const unsigned long evma_connect_to_unix_server (const char *server);
 

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -234,6 +234,17 @@ static VALUE t_add_oneshot_timer (VALUE self, VALUE interval)
 }
 
 
+/*******************
+t_cancel_oneshot_timer
+*******************/
+
+static VALUE t_cancel_oneshot_timer (VALUE self, VALUE signature)
+{
+	evma_uninstall_oneshot_timer (NUM2ULONG (signature));
+	return Qnil;
+}
+
+
 /**************
 t_start_server
 **************/
@@ -1120,6 +1131,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "run_machine", (VALUE(*)(...))t_run_machine_without_threads, 0);
 	rb_define_module_function (EmModule, "run_machine_without_threads", (VALUE(*)(...))t_run_machine_without_threads, 0);
 	rb_define_module_function (EmModule, "add_oneshot_timer", (VALUE(*)(...))t_add_oneshot_timer, 1);
+	rb_define_module_function (EmModule, "cancel_oneshot_timer", (VALUE(*)(...))t_cancel_oneshot_timer, 1);
 	rb_define_module_function (EmModule, "start_tcp_server", (VALUE(*)(...))t_start_server, 2);
 	rb_define_module_function (EmModule, "stop_tcp_server", (VALUE(*)(...))t_stop_server, 1);
 	rb_define_module_function (EmModule, "start_unix_server", (VALUE(*)(...))t_start_unix_server, 1);

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -56,6 +56,11 @@ module EventMachine
       Reactor.instance.install_oneshot_timer(interval / 1000)
     end
 
+    # #cancel_oneshot_timer
+    def cancel_oneshot_timer sig
+      Reactor.instance.uninstall_oneshot_timer(sig)
+    end
+
     # run_machine
     def run_machine
       Reactor.instance.run

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -355,7 +355,8 @@ module EventMachine
     if timer_or_sig.respond_to? :cancel
       timer_or_sig.cancel
     else
-      @timers[timer_or_sig] = false if @timers.has_key?(timer_or_sig)
+      cancel_oneshot_timer(timer_or_sig)
+      @timers.delete timer_or_sig
     end
   end
 
@@ -1389,7 +1390,6 @@ module EventMachine
       c.connection_completed
     elsif opcode == TimerFired
       t = @timers.delete( data )
-      return if t == false # timer cancelled
       t or raise UnknownTimerFired, "timer data: #{data}"
       t.call
     elsif opcode == ConnectionData

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -157,4 +157,21 @@ class TestTimers < Test::Unit::TestCase
     EM.set_max_timers(defaults)
   end
 
+  def test_timer_cancel_not_outstanding
+    defaults = EM.get_max_timers
+    EM.set_max_timers(100)
+
+    one_hundred_one_canceled_timers = proc { 101.times {
+      t = EM.add_timer(5) {}
+      EM.cancel_timer(t)
+    } }
+
+    EM.run {
+      one_hundred_one_canceled_timers.call
+      EM.stop
+    }
+  ensure
+    EM.set_max_timers(defaults)
+  end
+
 end


### PR DESCRIPTION
See http://github.com/eventmachine/eventmachine/issues/#issue/89

This patch adds EventMachine_t::UninstallOneshotTimer, which removes a timer from the internal multimap.  A new map is added, taking signatures to firing times, to keep this removal efficient.

The method is exposed to ruby as EM.cancel_oneshot_timer via evma_uninstall_oneshot_timer.  EM.cancel_timer now delegates to it, instead of setting the timer callback to false and ignoring it later.

A timer may still safely cancel itself (a no-op) from within its own callback.

The pure-ruby reactor (which relied on the logic in EM.cancel_timer) also supports #cancel_oneshot_timer.  emwin.cpp, cplusplus.cpp and the java port have not been touched.
