### PR TITLE
Improvements to LineProtocol and have it autoload.

### DIFF
--- a/lib/em/protocols.rb
+++ b/lib/em/protocols.rb
@@ -32,5 +32,6 @@ module EventMachine
     autoload :Postgres3, 'em/protocols/postgres3'
     autoload :ObjectProtocol, 'em/protocols/object_protocol'
     autoload :Socks4, 'em/protocols/socks4'
+    autoload :LineProtocol, 'em/protocols/line_protocol'
   end
 end

--- a/lib/em/protocols/line_protocol.rb
+++ b/lib/em/protocols/line_protocol.rb
@@ -14,8 +14,8 @@ module EventMachine
       def receive_data data # :nodoc:
         (@buf ||= '') << data
 
-        while line = @buf.slice!(/(.*)\r?\n/)
-          receive_line(line)
+        while @buf.slice!(/(.*?)\r?\n/)
+          receive_line($1)
         end
       end
 

--- a/tests/test_line_protocol.rb
+++ b/tests/test_line_protocol.rb
@@ -1,0 +1,33 @@
+require 'em_test_helper'
+
+class TestLineProtocol < Test::Unit::TestCase
+  class LineProtocolTestClass
+    include EM::Protocols::LineProtocol
+
+    def lines
+      @lines ||= []
+    end
+
+    def receive_line(line)
+      lines << line
+    end
+  end
+
+  def setup
+    @proto = LineProtocolTestClass.new
+  end
+
+  def test_simple_split_line
+    @proto.receive_data("this is")
+    assert_equal([], @proto.lines)
+
+    @proto.receive_data(" a test\n")
+    assert_equal(["this is a test"], @proto.lines)
+  end
+
+  def test_simple_lines
+    @proto.receive_data("aaa\nbbb\r\nccc\nddd")
+    assert_equal(%w(aaa bbb ccc), @proto.lines)
+  end
+
+end


### PR DESCRIPTION
I've fixed 3 things with LineProtocol:
- It no longer includes the new line characters when it calls receive_line
- It now has some basic tests
- It now gets autoloaded

Open Issue:
https://github.com/eventmachine/eventmachine/issues/issue/150
