### PR TITLE
UDP packets sent with send_datagram are mangled under JRuby

### DIFF
--- a/java/src/com/rubyeventmachine/EmReactor.java
+++ b/java/src/com/rubyeventmachine/EmReactor.java
@@ -442,8 +442,8 @@ public class EmReactor {
 		Connections.get(sig).setCommInactivityTimeout (mills);
 	}
 
-	public void sendDatagram (long sig, String data, int length, String recipAddress, int recipPort) {
-		sendDatagram (sig, ByteBuffer.wrap(data.getBytes()), recipAddress, recipPort);
+	public void sendDatagram (long sig, byte[] data, int length, String recipAddress, int recipPort) {
+		sendDatagram (sig, ByteBuffer.wrap(data), recipAddress, recipPort);
 	}
 
 	public void sendDatagram (long sig, ByteBuffer bb, String recipAddress, int recipPort) {

--- a/lib/jeventmachine.rb
+++ b/lib/jeventmachine.rb
@@ -118,7 +118,7 @@ module EventMachine
     @em.sendData sig, data.to_java_bytes
   end
   def self.send_datagram sig, data, length, address, port
-    @em.sendDatagram sig, data, length, address, port
+    @em.sendDatagram sig, data.to_java_bytes, length, address, port
   end
   def self.connect_server server, port
     bind_connect_server nil, nil, server, port


### PR DESCRIPTION
sendDatagram() in EmReactor.java should take a byte[] as the TCP sendData() function does.  Java String is not UTF safe and packets are mangled by the current implementation.
