### PR TITLE
EM::Connection#set_sock_opt method

### DIFF
--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -581,6 +581,24 @@ static VALUE t_get_sock_opt (VALUE self, VALUE signature, VALUE lev, VALUE optna
 	return rb_str_new(buf, len);
 }
 
+/* Set socket option
+ *
+ * call-seq:
+ *    EM.set_sock_opt(connection, level, optname, value) => true
+ */
+static VALUE t_set_sock_opt (VALUE self, VALUE signature, VALUE lev, VALUE optname, VALUE optval)
+{
+	int fd = evma_get_file_descriptor(NUM2ULONG(signature));
+	int level = NUM2INT(lev), option = NUM2INT(optname);
+	int val = NUM2INT(optval);
+
+	if (setsockopt(fd, level, option, &val, sizeof(val)) < 0) {
+		rb_sys_fail("setsockopt");
+	}
+
+	return Qtrue;
+}
+
 /********************
 t_is_notify_readable
 ********************/
@@ -1131,6 +1149,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "attach_fd", (VALUE (*)(...))t_attach_fd, 2);
 	rb_define_module_function (EmModule, "detach_fd", (VALUE (*)(...))t_detach_fd, 1);
 	rb_define_module_function (EmModule, "get_sock_opt", (VALUE (*)(...))t_get_sock_opt, 3);
+	rb_define_module_function (EmModule, "set_sock_opt", (VALUE (*)(...))t_set_sock_opt, 4);
 	rb_define_module_function (EmModule, "set_notify_readable", (VALUE (*)(...))t_set_notify_readable, 2);
 	rb_define_module_function (EmModule, "set_notify_writable", (VALUE (*)(...))t_set_notify_writable, 2);
 	rb_define_module_function (EmModule, "is_notify_readable", (VALUE (*)(...))t_is_notify_readable, 1);
@@ -1203,4 +1222,3 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_const (EmModule, "SslHandshakeCompleted", INT2NUM(108));
 
 }
-

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -184,6 +184,10 @@ module EventMachine
       EventMachine::get_sock_opt @signature, level, option
     end
 
+    def set_sock_opt(level, option, value)
+      EventMachine::set_sock_opt(@signature, level, option, value)
+    end
+
     # EventMachine::Connection#close_connection_after_writing is a variant of close_connection.
     # All of the descriptive comments given for close_connection also apply to
     # close_connection_after_writing, <i>with one exception:</i> If the connection has

--- a/tests/test_set_sock_opt.rb
+++ b/tests/test_set_sock_opt.rb
@@ -1,0 +1,40 @@
+require 'em_test_helper'
+require 'socket'
+
+class TestSetSockOpt < Test::Unit::TestCase
+
+  if EM.respond_to? :set_sock_opt and EM.respond_to? :get_sock_opt
+    def setup
+      assert(!EM.reactor_running?)
+    end
+
+    def teardown
+      assert(!EM.reactor_running?)
+    end
+
+    #-------------------------------------
+
+    def test_set_sock_opt
+      test = self
+      EM.run do
+        EM.connect 'google.com', 80, Module.new {
+          define_method :connection_completed do
+            val = get_sock_opt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).unpack('i').first
+            test.assert_not_equal 0, val
+            set_sock_opt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 0)
+            val = get_sock_opt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).unpack('i').first
+            test.assert_equal 0, val
+            EM.stop
+          end
+        }
+      end
+    end
+  else
+    warn "EM.set_sock_opt not implemented, skipping tests in #{__FILE__}"
+
+    # Because some rubies will complain if a TestCase class has no tests
+    def test_em_set_sock_opt_unsupported
+      assert true
+    end
+  end
+end


### PR DESCRIPTION
Allow modification of socket options. For example, if one wants to bring back Nagle algorithm.
