### PR TITLE
Many servers treat host:port as a different host from host and therefore 

### DIFF
--- a/lib/em/protocols/httpclient.rb
+++ b/lib/em/protocols/httpclient.rb
@@ -115,8 +115,8 @@ module EventMachine
 
         # Allow an override for the host header if it's not the connect-string.
         host = args[:host_header] || args[:host] || "_"
-        # For now, ALWAYS tuck in the port string, although we may want to omit it if it's the default.
-        port = args[:port]
+        # For now, tuck in the port string, unless it is port 80.
+        port = args[:port].to_i == 80 ? ":#{args[:port]}" : ""
 
         # POST items.
         postcontenttype = args[:contenttype] || "application/octet-stream"
@@ -127,7 +127,7 @@ module EventMachine
         # TODO: We ASSUME the caller wants to send a 1.1 request. May not be a good assumption.
         req = [
           "#{verb} #{request}#{qs} HTTP/#{version}",
-          "Host: #{host}:#{port}",
+          "Host: #{host}#{port}",
           "User-agent: Ruby EventMachine",
         ]
 


### PR DESCRIPTION
Many servers treat host:port as a different host from host and therefore provide a 404 for HttpClient and not for HttpClient2
