### PR TITLE
Added support for the NPN TLS when it is available.

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -431,6 +431,32 @@ extern "C" void evma_set_tls_parms (const unsigned long binding, const char *pri
 		ed->SetTlsParms (privatekey_filename, certchain_filename, (verify_peer == 1 ? true : false));
 }
 
+/****************************
+evma_set_negotiable_protocols
+*****************************/
+
+#ifdef OPENSSL_NPN_NEGOTIATED
+extern "C" void evma_set_negotiable_protocols (const unsigned long binding, const char *protocols)
+{
+	ensure_eventmachine("evma_set_negotiable_protocols");
+	EventableDescriptor *ed = dynamic_cast <EventableDescriptor*> (Bindable_t::GetObject (binding));
+	if (ed)
+		ed->SetNegotiableProtocols(protocols);
+}
+
+/***************************
+evma_get_negotiated_protocol
+****************************/
+
+extern "C" void evma_get_negotiated_protocol (const unsigned long binding, const unsigned char **data, unsigned *len)
+{
+	ensure_eventmachine("evma_get_negotiated_protocol");
+	EventableDescriptor *ed = dynamic_cast <EventableDescriptor*> (Bindable_t::GetObject (binding));
+	if (ed)
+		ed->GetNegotiatedProtocol(data, len);
+}
+#endif
+
 /******************
 evma_get_peer_cert
 ******************/

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -68,6 +68,11 @@ class EventableDescriptor: public Bindable_t
 		virtual bool GetSockname (struct sockaddr*, socklen_t*) {return false;}
 		virtual bool GetSubprocessPid (pid_t*) {return false;}
 
+		#ifdef OPENSSL_NPN_NEGOTIATED
+		virtual void SetNegotiableProtocols (const char *protocols) {}
+		virtual void GetNegotiatedProtocol (const unsigned char **data, unsigned *len) {}
+		#endif
+
 		virtual void StartTls() {}
 		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer) {}
 
@@ -190,6 +195,11 @@ class ConnectionDescriptor: public EventableDescriptor
 		virtual void StartTls();
 		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer);
 
+		#ifdef OPENSSL_NPN_NEGOTIATED
+		virtual void SetNegotiableProtocols (const char *protocols);
+		virtual void GetNegotiatedProtocol (const unsigned char **data, unsigned *len);
+		#endif
+
 		#ifdef WITH_SSL
 		virtual X509 *GetPeerCert();
 		virtual bool VerifySslPeer(const char*);
@@ -236,6 +246,10 @@ class ConnectionDescriptor: public EventableDescriptor
 		bool bHandshakeSignaled;
 		bool bSslVerifyPeer;
 		bool bSslPeerAccepted;
+		#endif
+
+		#ifdef OPENSSL_NPN_NEGOTIATED
+		std::string NegotiableProtocols;
 		#endif
 
 		#ifdef HAVE_KQUEUE

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -67,6 +67,11 @@ extern "C" {
 	void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filenane, int verify_peer);
 	void evma_start_tls (const unsigned long binding);
 
+	#ifdef OPENSSL_NPN_NEGOTIATED
+	void evma_set_negotiable_protocols (const unsigned long binding, const char *protocols);
+        void evma_get_negotiated_protocol (const unsigned long binding, const unsigned char **data, unsigned *len);
+	#endif
+
 	#ifdef WITH_SSL
 	X509 *evma_get_peer_cert (const unsigned long binding);
 	void evma_accept_ssl_peer (const unsigned long binding);

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -311,6 +311,41 @@ static VALUE t_set_tls_parms (VALUE self, VALUE signature, VALUE privkeyfile, VA
 	return Qnil;
 }
 
+/*************************
+t_set_negotiable_protocols
+**************************/
+
+static VALUE t_set_negotiable_protocols (VALUE self, VALUE signature, VALUE protocols)
+{
+	#ifdef OPENSSL_NPN_NEGOTIATED
+	evma_set_negotiable_protocols (NUM2ULONG (signature), StringValuePtr (protocols));
+	#endif
+	return Qnil;
+}
+
+/************************
+t_get_negotiated_protocol
+*************************/
+
+static VALUE t_get_negotiated_protocol (VALUE self, VALUE signature)
+{
+	VALUE ret = Qnil;
+
+	#ifdef OPENSSL_NPN_NEGOTIATED
+
+	const unsigned char *npn_proto;
+	unsigned int npn_proto_len;
+
+	evma_get_negotiated_protocol (NUM2ULONG (signature), &npn_proto, &npn_proto_len);
+	if (npn_proto_len != 0) {
+		ret = rb_str_new((const char *)npn_proto, npn_proto_len);
+	}
+
+	#endif
+
+	return ret;
+}
+
 /***************
 t_get_peer_cert
 ***************/
@@ -1121,6 +1156,10 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "start_unix_server", (VALUE(*)(...))t_start_unix_server, 1);
 	rb_define_module_function (EmModule, "set_tls_parms", (VALUE(*)(...))t_set_tls_parms, 4);
 	rb_define_module_function (EmModule, "start_tls", (VALUE(*)(...))t_start_tls, 1);
+	#ifdef OPENSSL_NPN_NEGOTIATED
+	rb_define_module_function (EmModule, "set_negotiable_protocols", (VALUE(*)(...))t_set_negotiable_protocols, 2);
+	rb_define_module_function (EmModule, "get_negotiated_protocol", (VALUE(*)(...))t_get_negotiated_protocol, 1);
+	#endif 
 	rb_define_module_function (EmModule, "get_peer_cert", (VALUE(*)(...))t_get_peer_cert, 1);
 	rb_define_module_function (EmModule, "send_data", (VALUE(*)(...))t_send_data, 3);
 	rb_define_module_function (EmModule, "send_datagram", (VALUE(*)(...))t_send_datagram, 5);

--- a/ext/ssl.h
+++ b/ext/ssl.h
@@ -57,7 +57,11 @@ class SslBox_t
 class SslBox_t
 {
 	public:
+		#ifdef OPENSSL_NPN_NEGOTIATED
+		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &nextprotos, bool verify_peer, const unsigned long binding);
+		#else
 		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, const unsigned long binding);
+		#endif
 		virtual ~SslBox_t();
 
 		int PutPlaintext (const char*, int);
@@ -67,6 +71,10 @@ class SslBox_t
 		bool CanGetCiphertext();
 		int GetCiphertext (char*, int);
 		bool IsHandshakeCompleted() {return bHandshakeCompleted;}
+
+		#ifdef OPENSSL_NPN_NEGOTIATED
+		void GetNegotiatedProtocol (const unsigned char **data, unsigned *len);
+		#endif
 
 		X509 *GetPeerCert();
 

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -388,6 +388,32 @@ module EventMachine
       EventMachine::get_peer_cert @signature
     end
 
+    # set_negotiable_protocols is used to set the protocols supported when using the
+    # TLS NPN extension
+    # This needs to be called before start_tls
+    def set_negotiable_protocols(protocols)
+      protocols = ["http/1.1", "http/1.0"] if(protocols.nil? || protocols.length == 0)
+
+      proto_arr = []
+      proto_str = ""
+      protocols.each do |proto|
+        proto_arr << proto.length << proto
+        proto_str = proto_str + "CA" + proto.length.to_s
+      end
+
+      EventMachine::set_negotiable_protocols @signature, proto_arr.pack(proto_str)
+    end
+
+
+    # get_negotiated_protocol is used to get protocol that was selected by the
+    # TLS NPN extension from the list of protocols specified by a call to
+    # set_negotiable_protocols
+    # The most likely place to put this is in a ssl_handshake_completed
+    # callback
+    def get_negotiated_protocol
+      EventMachine::get_negotiated_protocol @signature
+    end
+
 
     # send_datagram is for sending UDP messages.
     # This method may be called from any Connection object that refers


### PR DESCRIPTION
Instructions for building against a version of OpenSSL that supports NPN can be found here along with an example for use with SPDY: https://gist.github.com/944386
