### PR TITLE
Fix require line in em_test_helper.rb so that rake test will work in 1.9.2

### DIFF
--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -1,4 +1,4 @@
-require 'lib/eventmachine'
+require 'eventmachine'
 require 'test/unit'
 require 'rbconfig'
 require 'socket'


### PR DESCRIPTION
A previous commit changed the require line in em_test_helper.rb so that `rake test` no longer functioned in ruby 1.9.2. This commit fixes that.
