### PR TITLE
Add option to start streaming from a custom position in FileStreamer

### DIFF
--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -637,6 +637,8 @@ module EventMachine
     #
     # @option args [Boolean] :http_chunks (false) If true, this method will stream the file data in a format
     #                                             compatible with the HTTP chunked-transfer encoding
+    # @option args [Fixnum]  :position    (0)     Position (in bytes) to start reading the file from. Only
+    #                                             applies to files larger than 16k.
     #
     # @param [String] filename Local path of the file to stream
     # @param [Hash] args Options


### PR DESCRIPTION
This allows HTTP servers to serve HTTP Range requests using EM::FileStreamer by passing in a position to start from.

For example, a HTTP request for a file sent with the header `Range: bytes=50000-` can be served using `EventMachine::FileStreamer.new(connection, filename, :position => 50000`

I've also fixed test_stream_large_file_data to actually test a large file (a large file being larger that 16k)
