### PR TITLE
Modified TimeTilNextEvent to calculate based on current time

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -673,13 +673,13 @@ EventMachine_t::_TimeTilNextEvent
 
 timeval EventMachine_t::_TimeTilNextEvent()
 {
-  // 29jul11: Changed calculation base from MyCurrentLoopTime to the 
-  // real time. As MyCurrentLoopTime is set at the beginning of an
-  // iteration and this calculation is done at the end, evenmachine
-  // will potentially oversleep by the amount of time the iteration
-  // took to execute.
+	// 29jul11: Changed calculation base from MyCurrentLoopTime to the 
+	// real time. As MyCurrentLoopTime is set at the beginning of an
+	// iteration and this calculation is done at the end, evenmachine
+	// will potentially oversleep by the amount of time the iteration
+	// took to execute.
 	uint64_t next_event = 0;
-  uint64_t current_time = GetRealTime();
+	uint64_t current_time = GetRealTime();
 
 	if (!Heartbeats.empty()) {
 		multimap<uint64_t,EventableDescriptor*>::iterator heartbeats = Heartbeats.begin();


### PR DESCRIPTION
This prevents eventmachine from oversleeping the amount of time an iteration took. More information on: http://groups.google.com/group/eventmachine/browse_thread/thread/d35457ccf9f66241.
