### PR TITLE
Remove RDoc document control commands

### DIFF
--- a/lib/em/process_watch.rb
+++ b/lib/em/process_watch.rb
@@ -3,12 +3,13 @@ module EventMachine
   # This is subclassed from EventMachine::Connection for use with the process monitoring API. Read the
   # documentation on the instance methods of this class, and for a full explanation see EventMachine.watch_process.
   class ProcessWatch < Connection
-    # :stopdoc:
+    # @private
     Cfork = 'fork'.freeze
+    # @private
     Cexit = 'exit'.freeze
-    # :startdoc:
 
-    def receive_data(data) # :nodoc:
+    # @private
+    def receive_data(data)
       case data
       when Cfork
         process_forked

--- a/lib/em/processes.rb
+++ b/lib/em/processes.rb
@@ -39,7 +39,8 @@ module EventMachine
   class DeferrableChildProcess < EventMachine::Connection
     include EventMachine::Deferrable
 
-    def initialize # :nodoc:
+    # @private
+    def initialize
       super
       @data = []
     end
@@ -60,16 +61,19 @@ module EventMachine
       EventMachine.popen( cmd, DeferrableChildProcess )
     end
 
-    def receive_data data # :nodoc:
+    # @private
+    def receive_data data
       @data << data
     end
 
-    def unbind # :nodoc:
+    # @private
+    def unbind
       succeed( @data.join )
     end
   end
 
-  class SystemCmd < EventMachine::Connection # :nodoc:
+  # @private
+  class SystemCmd < EventMachine::Connection
     def initialize cb
       @cb = cb
       @output = []

--- a/lib/em/protocols/httpclient2.rb
+++ b/lib/em/protocols/httpclient2.rb
@@ -51,7 +51,8 @@ module EventMachine
         @requests = nil
       end
 
-      class Request # :nodoc:
+      # @private
+      class Request
         include Deferrable
 
         attr_reader :version
@@ -283,12 +284,12 @@ module EventMachine
         request args
       end
 
-      # :stopdoc:
 
       #--
       # Compute and remember a string to be used as the host header in HTTP requests
       # unless the user overrides it with an argument to #request.
       #
+      # @private
       def set_default_host_header host, port, ssl
         if (ssl and port != 443) or (!ssl and port != 80)
           @host_header = "#{host}:#{port}"
@@ -298,11 +299,13 @@ module EventMachine
       end
 
 
+      # @private
       def post_init
         super
         @connected = EM::DefaultDeferrable.new
       end
 
+      # @private
       def connection_completed
         super
         @connected.succeed
@@ -320,12 +323,14 @@ module EventMachine
       # Set and remember a flag (@closed) so we can immediately fail any
       # subsequent requests.
       #
+      # @private
       def unbind
         super
         @closed = true
         (@requests || []).each {|r| r.fail}
       end
 
+      # @private
       def request args
         args[:host_header] = @host_header unless args.has_key?(:host_header)
         args[:authorization] = @authorization unless args.has_key?(:authorization)
@@ -339,6 +344,7 @@ module EventMachine
         r
       end
 
+      # @private
       def receive_line ln
         if req = @requests.last
           req.receive_line ln
@@ -346,8 +352,9 @@ module EventMachine
           p "??????????"
           p ln
         end
-
       end
+
+      # @private
       def receive_binary_data text
         @requests.last.receive_text text
       end
@@ -355,11 +362,10 @@ module EventMachine
       #--
       # Called by a Request object when it completes.
       #
+      # @private
       def pop_request
         @requests.pop
       end
-
-      # :startdoc:
     end
 
 

--- a/lib/em/protocols/line_protocol.rb
+++ b/lib/em/protocols/line_protocol.rb
@@ -11,7 +11,8 @@ module EventMachine
     #  end
     #
     module LineProtocol
-      def receive_data data # :nodoc:
+      # @private
+      def receive_data data
         (@buf ||= '') << data
 
         while line = @buf.slice!(/(.*)\r?\n/)

--- a/lib/em/protocols/memcache.rb
+++ b/lib/em/protocols/memcache.rb
@@ -32,18 +32,23 @@ module EventMachine
       ##
       # constants
 
-      # :stopdoc:
       unless defined? Cempty
+        # @private
         Cstored    = 'STORED'.freeze
+        # @private
         Cend       = 'END'.freeze
+        # @private
         Cdeleted   = 'DELETED'.freeze
+        # @private
         Cunknown   = 'NOT_FOUND'.freeze
+        # @private
         Cerror     = 'ERROR'.freeze
 
+        # @private
         Cempty     = ''.freeze
+        # @private
         Cdelimiter = "\r\n".freeze
       end
-      # :startdoc:
 
       ##
       # commands
@@ -110,9 +115,7 @@ module EventMachine
         EM.connect host, port, self, host, port
       end
 
-      # :stopdoc:
-
-      def send_cmd cmd, key, flags = 0, exptime = 0, bytes = 0, noreply = false # :nodoc:
+      def send_cmd cmd, key, flags = 0, exptime = 0, bytes = 0, noreply = false
         send_data "#{cmd} #{key} #{flags} #{exptime} #{bytes}#{noreply ? ' noreply' : ''}\r\n"
       end
       private :send_cmd
@@ -120,16 +123,19 @@ module EventMachine
       ##
       # errors
 
+      # @private
       class ParserError < StandardError
       end
 
       ##
       # em hooks
 
+      # @private
       def initialize host, port = 11211
         @host, @port = host, port
       end
 
+      # @private
       def connection_completed
         @get_cbs = []
         @set_cbs = []
@@ -148,6 +154,7 @@ module EventMachine
       # 19Feb09 Switched to a custom parser, LineText2 is recursive and can cause
       #         stack overflows when there is too much data.
       # include EM::P::LineText2
+      # @private
       def receive_data data
         (@buffer||='') << data
 
@@ -164,6 +171,7 @@ module EventMachine
 
       #--
       # def receive_line line
+      # @private
       def process_cmd line
         case line.strip
         when /^VALUE\s+(.+?)\s+(\d+)\s+(\d+)/ # VALUE <key> <flags> <bytes>
@@ -209,6 +217,7 @@ module EventMachine
       #   @values[@cur_key] = data[0..-3]
       # end
 
+      # @private
       def unbind
         if @connected or @reconnecting
           EM.add_timer(1){ reconnect @host, @port }
@@ -219,8 +228,6 @@ module EventMachine
           raise 'Unable to connect to memcached server'
         end
       end
-
-      # :startdoc:
     end
   end
 end
@@ -229,7 +236,8 @@ if __FILE__ == $0
   # ruby -I ext:lib -r eventmachine -rubygems lib/protocols/memcache.rb
   require 'em/spec'
 
-  class TestConnection # :nodoc:
+  # @private
+  class TestConnection
     include EM::P::Memcache
     def send_data data
       sent_data << data

--- a/lib/em/protocols/object_protocol.rb
+++ b/lib/em/protocols/object_protocol.rb
@@ -17,7 +17,8 @@ module EventMachine
         Marshal
       end
 
-      def receive_data data # :nodoc:
+      # @private
+      def receive_data data
         (@buf ||= '') << data
 
         while @buf.size >= 4

--- a/lib/em/protocols/postgres3.rb
+++ b/lib/em/protocols/postgres3.rb
@@ -29,7 +29,8 @@ require 'postgres-pr/message'
 require 'postgres-pr/connection'
 require 'stringio'
 
-class StringIO # :nodoc:
+# @private
+class StringIO
   # Reads exactly +n+ bytes.
   #
   # If the data read is nil an EOFError is raised.

--- a/lib/em/protocols/smtpclient.rb
+++ b/lib/em/protocols/smtpclient.rb
@@ -162,15 +162,15 @@ module EventMachine
         }
       end
 
-      # :stopdoc:
-
       attr_writer :args
 
+      # @private
       def post_init
         @return_values = OpenStruct.new
         @return_values.start_time = Time.now
       end
 
+      # @private
       def connection_completed
         @responder = :receive_signon
         @msg = []
@@ -181,6 +181,7 @@ module EventMachine
       # set a deferred success because the caller will already have done it
       # (no need to wait until the connection closes to invoke the callbacks).
       #
+      # @private
       def unbind
         unless @succeeded
           @return_values.elapsed_time = Time.now - @return_values.start_time
@@ -191,6 +192,7 @@ module EventMachine
         end
       end
 
+      # @private
       def receive_line ln
         $>.puts ln if @args[:verbose]
         @range = ln[0...1].to_i
@@ -202,6 +204,8 @@ module EventMachine
           @msg.clear
         end
       end
+
+      private
 
       # We encountered an error from the server and will close the connection.
       # Use the error and message the server returned.
@@ -356,8 +360,6 @@ module EventMachine
         @return_values.message = @msg
         set_deferred_status :succeeded, @return_values
       end
-
-      # :startdoc:
     end
   end
 end

--- a/lib/em/protocols/stomp.rb
+++ b/lib/em/protocols/stomp.rb
@@ -64,12 +64,14 @@ module EventMachine
         # Body of the message
         attr_accessor :body
 
-        def initialize # :nodoc:
+        # @private
+        def initialize
           @header = {}
           @state = :precommand
           @content_length = nil
         end
-        def consume_line line # :nodoc:
+        # @private
+        def consume_line line
           if @state == :precommand
             unless line =~ /\A\s*\Z/
               @command = line
@@ -100,8 +102,7 @@ module EventMachine
         end
       end
 
-      # :stopdoc:
-
+      # @private
       def send_frame verb, headers={}, body=""
         ary = [verb, "\n"]
         headers.each {|k,v| ary << "#{k}:#{v}\n" }
@@ -113,6 +114,7 @@ module EventMachine
         send_data ary.join
       end
 
+      # @private
       def receive_line line
         @stomp_initialized || init_message_reader
         @stomp_message.consume_line(line) {|outcome|
@@ -127,20 +129,20 @@ module EventMachine
         }
       end
 
+      # @private
       def receive_binary_data data
         @stomp_message.body = data[0..-2]
         receive_msg(@stomp_message) if respond_to?(:receive_msg)
         init_message_reader
       end
 
+      # @private
       def init_message_reader
         @stomp_initialized = true
         set_delimiter "\n"
         set_line_mode
         @stomp_message = Message.new
       end
-
-      # :startdoc:
 
       # Invoked with an incoming Stomp::Message received from the STOMP server
       def receive_msg msg

--- a/lib/em/protocols/tcptest.rb
+++ b/lib/em/protocols/tcptest.rb
@@ -27,7 +27,8 @@
 module EventMachine
   module Protocols
 
-    class TcpConnectTester < Connection # :nodoc:
+    # @private
+    class TcpConnectTester < Connection
       include EventMachine::Deferrable
 
       def self.test( host, port )

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -886,7 +886,8 @@ end
 
 
 
-module EventMachine #:nodoc: all
+# @private
+module EventMachine
   # @private
   class DatagramObject < Selectable
     def initialize io

--- a/lib/em/spawnable.rb
+++ b/lib/em/spawnable.rb
@@ -55,7 +55,8 @@ module EventMachine
 
   end
 
-  class YieldBlockFromSpawnedProcess # :nodoc:
+  # @private
+  class YieldBlockFromSpawnedProcess
     def initialize block, notify
       @block = [block,notify]
     end
@@ -71,11 +72,13 @@ module EventMachine
     s
   end
 
-  def self.yield &block # :nodoc:
+  # @private
+  def self.yield &block
     return YieldBlockFromSpawnedProcess.new( block, false )
   end
 
-  def self.yield_and_notify &block # :nodoc:
+  # @private
+  def self.yield_and_notify &block
     return YieldBlockFromSpawnedProcess.new( block, true )
   end
 end

--- a/lib/em/streamer.rb
+++ b/lib/em/streamer.rb
@@ -50,7 +50,7 @@ module EventMachine
     end
 
     # @private
-    def stream_without_mapping filename # :nodoc:
+    def stream_without_mapping filename
       if @http_chunks
         @connection.send_data "#{@size.to_s(16)}\r\n"
         @connection.send_file_data filename
@@ -63,7 +63,7 @@ module EventMachine
     private :stream_without_mapping
 
     # @private
-    def stream_with_mapping filename # :nodoc:
+    def stream_with_mapping filename
       ensure_mapping_extension_is_present
 
       @position = 0

--- a/lib/em/timers.rb
+++ b/lib/em/timers.rb
@@ -45,10 +45,13 @@ module EventMachine
     # Fire the timer every interval seconds
     attr_accessor :interval
 
-    def schedule # :nodoc:
+    # @private
+    def schedule
       EventMachine::add_timer @interval, @work
     end
-    def fire # :nodoc:
+
+    # @private
+    def fire
       unless @cancelled
         @code.call
         schedule

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1372,9 +1372,8 @@ module EventMachine
     EM::set_heartbeat_interval time.to_f
   end
 
-  private
-
-  def self.event_callback conn_binding, opcode, data # :nodoc:
+  # @private
+  def self.event_callback conn_binding, opcode, data
     #
     # Changed 27Dec07: Eliminated the hookable error handling.
     # No one was using it, and it degraded performance significantly.
@@ -1446,7 +1445,7 @@ module EventMachine
   #
   #
   # @private
-  def self._open_file_for_writing filename, handler=nil # :nodoc:
+  def self._open_file_for_writing filename, handler=nil
     klass = klass_from_handler(Connection, handler)
 
     s = _write_file filename
@@ -1456,7 +1455,7 @@ module EventMachine
     c
   end
 
-  private
+  # @private
   def self.klass_from_handler(klass = Connection, handler = nil, *args)
     klass = if handler and handler.is_a?(Class)
       raise ArgumentError, "must provide module or subclass of #{klass.name}" unless klass >= handler


### PR DESCRIPTION
Replace :nodoc: and :stopdoc: with # @private.
