### PR TITLE
Warning cleanups for rake test

### DIFF
--- a/lib/em/completion.rb
+++ b/lib/em/completion.rb
@@ -248,7 +248,7 @@ module EventMachine
     def timeout(time, *args)
       cancel_timeout
       @timeout_timer = EM::Timer.new(time) do
-        fail *args unless completed?
+        fail(*args) unless completed?
       end
     end
 
@@ -287,7 +287,7 @@ module EventMachine
     # Iterate all callbacks for a given state, and remove then call them.
     def execute_state_callbacks(state)
       while callback = @callbacks[state].shift
-        callback.call *value
+        callback.call(*value)
       end
     end
 

--- a/lib/em/protocols/httpclient.rb
+++ b/lib/em/protocols/httpclient.rb
@@ -64,7 +64,7 @@ module EventMachine
       MaxPostContentLength = 20 * 1024 * 1024
 
       def initialize
-        STDERR.puts "HttpClient is deprecated and will be removed. EM-Http-Request should be used instead."
+        warn "HttpClient is deprecated and will be removed. EM-Http-Request should be used instead."
       end
 
       # @param args [Hash] The request arguments

--- a/lib/em/protocols/httpclient2.rb
+++ b/lib/em/protocols/httpclient2.rb
@@ -44,7 +44,7 @@ module EventMachine
       include LineText2
       
       def initialize
-        STDERR.puts "HttpClient2 is deprecated and will be removed. EM-Http-Request should be used instead."
+        warn "HttpClient2 is deprecated and will be removed. EM-Http-Request should be used instead."
 
         @authorization = nil
         @closed = nil

--- a/lib/em/protocols/smtpserver.rb
+++ b/lib/em/protocols/smtpserver.rb
@@ -357,7 +357,7 @@ module EventMachine
 
       def process_auth_line(line)
         plain = line.unpack("m").first
-        discard,user,psw = plain.split("\000")
+        _,user,psw = plain.split("\000")
         if receive_plain_auth user,psw
           send_data "235 authentication ok\r\n"
           @state << :auth

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -448,7 +448,7 @@ module EventMachine
           s = Socket.for_fd(@io.fileno)
           s.fcntl( Fcntl::F_SETFL, Fcntl::O_NONBLOCK )
         rescue Errno::EINVAL, Errno::EBADF
-          STDERR.puts "Serious error: unable to set descriptor non-blocking"
+          warn "Serious error: unable to set descriptor non-blocking"
         end
       end
       # TODO, should set CLOEXEC on Unix?

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 require 'rbconfig'
 require 'socket'
 
-Test::Unit::TestCase.class_eval do
+class Test::Unit::TestCase
   class EMTestTimeout < StandardError ; end
 
   def setup_timeout(timeout = TIMEOUT_INTERVAL)
@@ -38,7 +38,7 @@ Test::Unit::TestCase.class_eval do
   module PlatformHelper
     # http://blog.emptyway.com/2009/11/03/proper-way-to-detect-windows-platform-in-ruby/
     def windows?
-      Config::CONFIG['host_os'] =~ /mswin|mingw/
+      RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     end
 
     # http://stackoverflow.com/questions/1342535/how-can-i-tell-if-im-running-from-jruby-vs-ruby/1685970#1685970
@@ -52,4 +52,13 @@ Test::Unit::TestCase.class_eval do
 
   # Tests run significantly slower on windows. YMMV
   TIMEOUT_INTERVAL = windows? ? 1 : 0.25
+
+  def silent
+    backup, $VERBOSE = $VERBOSE, nil
+    begin
+      yield
+    ensure
+      $VERBOSE = backup
+    end
+  end
 end

--- a/tests/test_completion.rb
+++ b/tests/test_completion.rb
@@ -158,7 +158,7 @@ class TestCompletion < Test::Unit::TestCase
     args = [1, 2, 3]
     EM.run do
       completion.timeout(0.0001, *args)
-      completion.errback { |*args| results << args }
+      completion.errback { |*errargs| results << errargs }
       completion.completion { EM.stop }
       EM.add_timer(0.1) { flunk 'test timed out' }
     end

--- a/tests/test_epoll.rb
+++ b/tests/test_epoll.rb
@@ -49,7 +49,7 @@ class TestEpoll < Test::Unit::TestCase
   # XXX this test causes all sort of weird issues on OSX (when run as part of the suite)
   def _test_descriptors
     EM.epoll
-    s = EM.set_descriptor_table_size 60000
+    EM.set_descriptor_table_size 60000
     EM.run {
       EM.start_server "127.0.0.1", 9800, TestEchoServer
       $n = 0
@@ -101,7 +101,7 @@ class TestEpoll < Test::Unit::TestCase
   def _test_unix_domain
     fn = "/tmp/xxx.chain"
     EM.epoll
-    s = EM.set_descriptor_table_size 60000
+    EM.set_descriptor_table_size 60000
     EM.run {
       # The pure-Ruby version won't let us open the socket if the node already exists.
       # Not sure, that actually may be correct and the compiled version is wrong.

--- a/tests/test_httpclient.rb
+++ b/tests/test_httpclient.rb
@@ -16,7 +16,7 @@ class TestHttpClient < Test::Unit::TestCase
   def test_http_client
     ok = false
     EM.run {
-      c = EM::P::HttpClient.send :request, :host => "www.google.com", :port => 80
+      c = silent { EM::P::HttpClient.send :request, :host => "www.google.com", :port => 80 }
       c.callback {
         ok = true
         EM.stop
@@ -31,7 +31,7 @@ class TestHttpClient < Test::Unit::TestCase
   def test_http_client_1
     ok = false
     EM.run {
-      c = EM::P::HttpClient.send :request, :host => "www.google.com", :port => 80
+      c = silent { EM::P::HttpClient.send :request, :host => "www.google.com", :port => 80 }
       c.callback {ok = true; EM.stop}
       c.errback {EM.stop}
     }
@@ -43,7 +43,7 @@ class TestHttpClient < Test::Unit::TestCase
   def test_http_client_2
     ok = false
     EM.run {
-      c = EM::P::HttpClient.send :request, :host => "www.google.com", :port => 80
+      c = silent { EM::P::HttpClient.send :request, :host => "www.google.com", :port => 80 }
       c.callback {|result|
         ok = true;
         EM.stop
@@ -75,7 +75,7 @@ class TestHttpClient < Test::Unit::TestCase
       ok = false
       EM.run {
         EM.start_server "127.0.0.1", 9701, EmptyContent
-        c = EM::P::HttpClient.send :request, :host => "127.0.0.1", :port => 9701
+        c = silent { EM::P::HttpClient.send :request, :host => "127.0.0.1", :port => 9701 }
         c.callback {|result|
           ok = true
           EM.stop
@@ -134,14 +134,14 @@ class TestHttpClient < Test::Unit::TestCase
       EM.run {
         EM.start_server Localhost, Localport, PostContent
         setup_timeout(2)
-        c = EM::P::HttpClient.request(
+        c = silent { EM::P::HttpClient.request(
           :host=>Localhost,
           :port=>Localport,
           :method=>:post,
           :request=>"/aaa",
           :content=>"XYZ",
           :content_type=>"text/plain"
-        )
+        )}
         c.callback {|r|
           response = r
           EM.stop
@@ -158,7 +158,7 @@ class TestHttpClient < Test::Unit::TestCase
   def test_cookie
     ok = false
     EM.run {
-      c = EM::Protocols::HttpClient.send :request, :host => "www.google.com", :port => 80, :cookie=>"aaa=bbb"
+      c = silent { EM::Protocols::HttpClient.send :request, :host => "www.google.com", :port => 80, :cookie=>"aaa=bbb" }
       c.callback {|result|
         ok = true;
         EM.stop
@@ -173,11 +173,11 @@ class TestHttpClient < Test::Unit::TestCase
   def test_version_1_0
     ok = false
     EM.run {
-      c = EM::P::HttpClient.request(
+      c = silent { EM::P::HttpClient.request(
         :host => "www.google.com",
         :port => 80,
         :version => "1.0"
-      )
+      )}
       c.callback {|result|
         ok = true;
         EM.stop

--- a/tests/test_httpclient2.rb
+++ b/tests/test_httpclient2.rb
@@ -22,8 +22,10 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_connect
     EM.run {
       EM.start_server Localhost, Localport, TestServer
-      http1 = EM::P::HttpClient2.connect Localhost, Localport
-      http2 = EM::P::HttpClient2.connect( :host=>Localhost, :port=>Localport )
+      silent do
+        EM::P::HttpClient2.connect Localhost, Localport
+        EM::P::HttpClient2.connect( :host=>Localhost, :port=>Localport )
+      end
       EM.stop
     }
   end
@@ -33,7 +35,7 @@ class TestHttpClient2 < Test::Unit::TestCase
     EM.run {
       EM.start_server Localhost, Localport, TestServer
       assert_raises( ArgumentError ) {
-        EM::P::HttpClient2.connect Localhost, "xxx"
+        silent { EM::P::HttpClient2.connect Localhost, "xxx" }
       }
       EM.stop
     }
@@ -42,7 +44,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_bad_server
     err = nil
     EM.run {
-      http = EM::P::HttpClient2.connect Localhost, 9999
+      http = silent { EM::P::HttpClient2.connect Localhost, 9999 }
       d = http.get "/"
       d.errback { err = true; d.internal_error; EM.stop }
     }
@@ -52,7 +54,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_get
     content = nil
     EM.run {
-      http = EM::P::HttpClient2.connect "google.com", 80
+      http = silent { EM::P::HttpClient2.connect "google.com", 80 }
       d = http.get "/"
       d.callback {
         content = d.content
@@ -68,7 +70,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def _test_get_multiple
     content = nil
     EM.run {
-      http = EM::P::HttpClient2.connect "google.com", 80
+      http = silent { EM::P::HttpClient2.connect "google.com", 80 }
       d = http.get "/"
       d.callback {
         e = http.get "/"
@@ -84,7 +86,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_get_pipeline
     headers, headers2 = nil, nil
     EM.run {
-      http = EM::P::HttpClient2.connect "google.com", 80
+      http = silent { EM::P::HttpClient2.connect "google.com", 80 }
       d = http.get("/")
       d.callback {
         headers = d.headers
@@ -104,7 +106,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_authheader
     EM.run {
       EM.start_server Localhost, Localport, TestServer
-      http = EM::P::HttpClient2.connect Localhost, 18842
+      http = silent { EM::P::HttpClient2.connect Localhost, 18842 }
       d = http.get :url=>"/", :authorization=>"Basic xxx"
       d.callback {EM.stop}
       d.errback {EM.stop}
@@ -114,7 +116,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_https_get
     d = nil
     EM.run {
-      http = EM::P::HttpClient2.connect :host => 'www.apple.com', :port => 443, :ssl => true
+      http = silent { EM::P::HttpClient2.connect :host => 'www.apple.com', :port => 443, :ssl => true }
       d = http.get "/"
       d.callback {
         EM.stop

--- a/tests/test_ltp.rb
+++ b/tests/test_ltp.rb
@@ -87,12 +87,8 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
 
   def test_lines_and_text
     output = ''
-    lines_received = []
-    text_received = []
     EM.run {
-      EM.start_server( "127.0.0.1", @port, LineAndTextTest ) do |conn|
-        conn.instance_eval "@lines = lines_received; @text = text_received"
-      end
+      EM.start_server( "127.0.0.1", @port, LineAndTextTest )
       setup_timeout
 
       EM.connect "127.0.0.1", @port, StopClient do |c|
@@ -125,12 +121,8 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
 
   def test_binary_text
     output = ''
-    lines_received = []
-    text_received = []
     EM.run {
-      EM.start_server( "127.0.0.1", @port, BinaryTextTest ) do |conn|
-        conn.instance_eval "@lines = lines_received; @text = text_received"
-      end
+      EM.start_server( "127.0.0.1", @port, BinaryTextTest )
       setup_timeout
 
       EM.connect "127.0.0.1", @port, StopClient do |c|

--- a/tests/test_processes.rb
+++ b/tests/test_processes.rb
@@ -78,7 +78,7 @@ class TestProcesses < Test::Unit::TestCase
 
     def test_em_system_cmd_arguments
       EM.run{
-        EM.system('sh', '--version', proc{ |process|
+        EM.system('echo', '1', '2', 'version', proc{ |process|
         }, proc{ |out,status|
           $out = out
           $status = status
@@ -86,7 +86,7 @@ class TestProcesses < Test::Unit::TestCase
         })
       }
 
-      assert_match(/version/i, $out)
+      assert_match(/1 2 version/i, $out)
     end
 
     def test_em_system_spaced_arguments

--- a/tests/test_threaded_resource.rb
+++ b/tests/test_threaded_resource.rb
@@ -42,7 +42,7 @@ class TestThreadedResource < Test::Unit::TestCase
     resource.dispatch do |o|
       o[:dispatch_thread] = Thread.current
     end
-    assert_not_equal Thread.current, object[:dispatch_thread]
+    assert_not_equal main, object[:dispatch_thread]
   end
 
   def test_shutdown


### PR DESCRIPTION
Library changes;
- add parentheses for ambiguous syntax
- use Kernel.warn instead of STDERR.puts

Updated tests as well to suppress warnings while running.
