### PR TITLE
Never close STDIN, STDOUT and STDERR (i.e. only close when fd > 2) Should

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -175,7 +175,7 @@ void EventableDescriptor::Close()
 
 	// Close the socket right now. Intended for emergencies.
 	if (MySocket != INVALID_SOCKET) {
-		MyEventMachine->Closing (this);
+		MyEventMachine->Deregister (this);
 		
 		// Do not close STDIN, STDOUT, STDERR
 		if (MySocket > 2 && !bWatchOnly) {

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1789,10 +1789,10 @@ void EventMachine_t::Modify (EventableDescriptor *ed)
 
 
 /***********************
-EventMachine_t::Closing
+EventMachine_t::Deregister
 ***********************/
 
-void EventMachine_t::Closing (EventableDescriptor *ed)
+void EventMachine_t::Deregister (EventableDescriptor *ed)
 {
 	if (!ed)
 		throw std::runtime_error ("modified bad descriptor");

--- a/ext/em.h
+++ b/ext/em.h
@@ -81,7 +81,7 @@ class EventMachine_t
 
 		void Add (EventableDescriptor*);
 		void Modify (EventableDescriptor*);
-		void Closing (EventableDescriptor*);
+		void Deregister (EventableDescriptor*);
 
 		const unsigned long AttachFD (int, bool);
 		int DetachFD (EventableDescriptor*);


### PR DESCRIPTION
Never close STDIN, STDOUT and STDERR (i.e. only close when fd > 2) Should solve #183
