### PR TITLE
Add EventMachine::attach_server

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -149,6 +149,16 @@ extern "C" int evma_detach_fd (const unsigned long binding)
 			return -1;
 }
 
+/*********************
+evma_attach_server_fd
+**********************/
+
+extern "C" const unsigned long evma_attach_server_fd (int file_descriptor)
+{
+   ensure_eventmachine("evma_attach_server_fd");
+   return EventMachine->AttachServerFD (file_descriptor);
+}
+
 /************************
 evma_get_file_descriptor
 ************************/

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -50,7 +50,8 @@ bool SetSocketNonblocking (SOCKET sd)
 EventableDescriptor::EventableDescriptor
 ****************************************/
 
-EventableDescriptor::EventableDescriptor (int sd, EventMachine_t *em):
+EventableDescriptor::EventableDescriptor (int sd, EventMachine_t *em, bool autoclose):
+	bAutoClose (autoclose),
 	bCloseNow (false),
 	bCloseAfterWriting (false),
 	MySocket (sd),
@@ -118,7 +119,9 @@ EventableDescriptor::~EventableDescriptor()
 	}
 	MyEventMachine->NumCloseScheduled--;
 	StopProxy();
-	Close();
+	if (bAutoClose) {
+		Close();
+	}
 }
 
 
@@ -1348,8 +1351,8 @@ void LoopbreakDescriptor::Write()
 AcceptorDescriptor::AcceptorDescriptor
 **************************************/
 
-AcceptorDescriptor::AcceptorDescriptor (int sd, EventMachine_t *parent_em):
-	EventableDescriptor (sd, parent_em)
+AcceptorDescriptor::AcceptorDescriptor (int sd, EventMachine_t *parent_em, bool autoclose):
+	EventableDescriptor (sd, parent_em, autoclose)
 {
 	#ifdef HAVE_EPOLL
 	EpollEvent.events = EPOLLIN;

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -36,7 +36,7 @@ class EventableDescriptor
 class EventableDescriptor: public Bindable_t
 {
 	public:
-		EventableDescriptor (int, EventMachine_t*);
+		EventableDescriptor (int, EventMachine_t*, bool = true);
 		virtual ~EventableDescriptor();
 
 		int GetSocket() {return MySocket;}
@@ -98,6 +98,7 @@ class EventableDescriptor: public Bindable_t
 		virtual uint64_t GetNextHeartbeat();
 
 	private:
+		bool bAutoClose;
 		bool bCloseNow;
 		bool bCloseAfterWriting;
 
@@ -310,7 +311,7 @@ class AcceptorDescriptor
 class AcceptorDescriptor: public EventableDescriptor
 {
 	public:
-		AcceptorDescriptor (int, EventMachine_t*);
+		AcceptorDescriptor (int, EventMachine_t*, bool = true);
 		virtual ~AcceptorDescriptor();
 
 		virtual void Read();

--- a/ext/em.h
+++ b/ext/em.h
@@ -94,6 +94,7 @@ class EventMachine_t
 
 		const unsigned long AttachFD (int, bool);
 		int DetachFD (EventableDescriptor*);
+		const unsigned long AttachServerFD (int);
 
 		void ArmKqueueWriter (EventableDescriptor*);
 		void ArmKqueueReader (EventableDescriptor*);

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -49,6 +49,7 @@ extern "C" {
 
 	const unsigned long evma_attach_fd (int file_descriptor, int watch_mode);
 	int evma_detach_fd (const unsigned long binding);
+	const unsigned long evma_attach_server_fd (int file_descriptor);
 	int evma_get_file_descriptor (const unsigned long binding);
 	int evma_is_notify_readable (const unsigned long binding);
 	void evma_set_notify_readable (const unsigned long binding, int mode);

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -566,6 +566,18 @@ static VALUE t_detach_fd (VALUE self, VALUE signature)
 	return INT2NUM(evma_detach_fd (NUM2ULONG (signature)));
 }
 
+/***********
+  t_attach_server_fd
+***********/
+
+static VALUE t_attach_server_fd (VALUE self, VALUE file_descriptor, VALUE watch_mode)
+{
+	const unsigned long f = evma_attach_server_fd (NUM2INT(file_descriptor));
+	if (!f)
+		rb_raise (rb_eRuntimeError, "no connection");
+	return ULONG2NUM (f);
+}
+
 /**************
 t_get_sock_opt
 **************/
@@ -1179,6 +1191,7 @@ extern "C" void Init_rubyeventmachine()
 
 	rb_define_module_function (EmModule, "attach_fd", (VALUE (*)(...))t_attach_fd, 2);
 	rb_define_module_function (EmModule, "detach_fd", (VALUE (*)(...))t_detach_fd, 1);
+	rb_define_module_function (EmModule, "attach_server_fd", (VALUE (*)(...))t_attach_server_fd, 1);
 	rb_define_module_function (EmModule, "get_sock_opt", (VALUE (*)(...))t_get_sock_opt, 3);
 	rb_define_module_function (EmModule, "set_sock_opt", (VALUE (*)(...))t_set_sock_opt, 4);
 	rb_define_module_function (EmModule, "set_notify_readable", (VALUE (*)(...))t_set_notify_readable, 2);

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -751,6 +751,28 @@ module EventMachine
     c
   end
 
+  # Attaches a server IO object or file descriptor to the eventloop.
+  # This function behaves just like start_server but allows you to reuse
+  # an already existing file descriptor instead of having EventMachine create
+  # one. The descriptor must be accept()able and will be set as non-blocking.
+  #
+  # Unlike start_server however, the file descriptor is not closed when
+  # EventMachine is released, so you will have to do any cleanups manually.
+  # If +io+ is an IO object then a reference to it will be kept until
+  # EventMachine is released, so that the file descriptor isn't accidentally
+  # closed by the garbage collector.
+  def EventMachine::attach_server io, handler = nil, *args, &block
+    klass = klass_from_handler(Connection, handler, *args)
+    if io.respond_to?(:fileno)
+      fd = defined?(JRuby) ? JRuby.runtime.getDescriptorByFileno(io.fileno).getChannel : io.fileno
+    else
+      fd = io
+    end
+    s = attach_server_fd(fd)
+    @acceptors[s] = [klass,args,block,io]
+    s
+  end
+
 
   # Connect to a given host/port and re-use the provided {EventMachine::Connection} instance.
   # Consider also {EventMachine::Connection#reconnect}.

--- a/tests/test_attach.rb
+++ b/tests/test_attach.rb
@@ -4,6 +4,7 @@ require 'socket'
 class TestAttach < Test::Unit::TestCase
   class EchoServer < EM::Connection
     def receive_data data
+      $received_data << data
       send_data data
     end
   end
@@ -31,12 +32,14 @@ class TestAttach < Test::Unit::TestCase
   def setup
     @port = next_port
     $read, $r, $w, $fd = nil
+    $received_data = ""
   end
 
   def teardown
     [$r, $w].each do |io|
       io.close rescue nil
     end
+    $received_data = nil
   end
 
   def test_attach
@@ -54,6 +57,25 @@ class TestAttach < Test::Unit::TestCase
     end
     assert_equal false, socket.closed?
     assert_equal socket.readline, "def\n"
+  end
+
+  def test_attach_server
+    $before = TCPServer.new("127.0.0.1", @port)
+    EM.run {
+      EM.attach_server $before, EchoServer
+
+      handler = Class.new(EM::Connection) do
+        def initialize
+          send_data "hello world"
+          close_connection_after_writing
+          EM.add_timer(0.1) { EM.stop }
+        end
+      end
+      EM.connect("127.0.0.1", @port, handler)
+    }
+
+    assert_equal false, $before.closed?
+    assert_equal "hello world", $received_data
   end
 
   module PipeWatch


### PR DESCRIPTION
EventMachine::attach_Server is for attaching an arbitrary server IO
object or file descriptor to the event loop.

Tries to fix #93.

Signed-off-by: Ramon Marco L. Navarro ramonmaruko@gmail.com
