### PR TITLE
Add a method to stop EM gracefully.

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -415,6 +415,15 @@ extern "C" void evma_stop_machine()
 	EventMachine->ScheduleHalt();
 }
 
+/**************************
+evma_graceful_stop_machine
+**************************/
+
+extern "C" void evma_graceful_stop_machine()
+{
+	ensure_eventmachine("evma_graceful_stop_machine");
+	EventMachine->ScheduleGracefulHalt();
+}
 
 /**************
 evma_start_tls

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -75,6 +75,7 @@ EventMachine_t::EventMachine_t (EMCallback event_callback):
 	LoopBreakerWriter (-1),
 	NumCloseScheduled (0),
 	bTerminateSignalReceived (false),
+	bGracefulTerminateSignalReceived (false),
 	bEpoll (false),
 	epfd (-1),
 	bKqueue (false),
@@ -189,7 +190,20 @@ void EventMachine_t::ScheduleHalt()
 	bTerminateSignalReceived = true;
 }
 
+/************************************
+EventMachine_t::ScheduleGracefulHalt
+*************************************/
 
+void EventMachine_t::ScheduleGracefulHalt()
+{
+  /* This is how we stop the machine.
+   *
+   * It is like ScheduleHalt(), but instead of immediately breaking out of the
+   * event loop, it will schedule all sockets to close after writing. Once all
+   * sockets have closed or some maximum time delay is reached, it will exit.
+   */
+	bGracefulTerminateSignalReceived = true;
+}
 
 /*******************************
 EventMachine_t::SetTimerQuantum
@@ -471,6 +485,9 @@ void EventMachine_t::Run()
 	}
 	#endif
 
+	uint64_t shutdown_time = 0;
+	uint64_t max_shutdown_wait = 15 * 1000000; // 15 seconds
+
 	while (true) {
 		_UpdateTime();
 		_RunTimers();
@@ -486,6 +503,37 @@ void EventMachine_t::Run()
 			break;
 		if (bTerminateSignalReceived)
 			break;
+		if (bGracefulTerminateSignalReceived) {
+			if (!shutdown_time)
+				shutdown_time = MyCurrentLoopTime;
+
+			/* Close all sockets after they write their data.
+			 *
+			 * We call this multiple times in case there are new
+			 * accepted connections before the listen socket
+			 * finishes closing down.
+			 */
+			_ScheduleCloseAllDescriptors(true);
+
+			/* Actually shut down if no sockets remain or we've
+			 * waited longer than max_shutdown_wait.
+			 */
+			if (!GetConnectionCount()) {
+				break;
+			}
+			if ((MyCurrentLoopTime - shutdown_time) > max_shutdown_wait) {
+				fprintf(stderr,
+					"warning: EventMachine hit max_shutdown_wait, killing %d sockets\n",
+					GetConnectionCount());
+				int i;
+				int nSockets = Descriptors.size();
+				for (i = 0; i < nSockets; i++) {
+					fprintf(stderr, "warning: fd %d not closed\n",
+							Descriptors[i]->GetSocket());
+				}
+				break;
+			}
+		}
 	}
 }
 
@@ -711,6 +759,20 @@ timeval EventMachine_t::_TimeTilNextEvent()
 	}
 
 	return tv;
+}
+
+/********************************************
+EventMachine_t::_ScheduleCloseAllDescriptors
+********************************************/
+
+void EventMachine_t::_ScheduleCloseAllDescriptors(bool after_writing)
+{
+	int i;
+	int nSockets = Descriptors.size();
+	for (i=0; i < nSockets; i++) {
+		EventableDescriptor *ed = Descriptors[i];
+		ed->ScheduleClose(after_writing);
+	}
 }
 
 /*******************************
@@ -2235,7 +2297,7 @@ void EventMachine_t::_ReadInotifyEvents()
 		int returned = read(inotify->GetSocket(), buffer, sizeof(buffer));
 		assert(!(returned == 0 || returned == -1 && errno == EINVAL));
 		if (returned <= 0) {
-		    break;
+			break;
 		}
 		int current = 0;
 		while (current < returned) {

--- a/ext/em.h
+++ b/ext/em.h
@@ -76,6 +76,7 @@ class EventMachine_t
 
 		void Run();
 		void ScheduleHalt();
+		void ScheduleGracefulHalt();
 		void SignalLoopBreaker();
 		const unsigned long InstallOneshotTimer (int);
 		const unsigned long ConnectToServer (const char *, int, const char *, int);
@@ -148,6 +149,7 @@ class EventMachine_t
 		void _ModifyDescriptors();
 		void _InitializeLoopBreaker();
 		void _CleanupSockets();
+		void _ScheduleCloseAllDescriptors(bool after_writing);
 
 		bool _RunSelectOnce();
 		bool _RunEpollOnce();
@@ -201,6 +203,7 @@ class EventMachine_t
 
 	private:
 		bool bTerminateSignalReceived;
+		bool bGracefulTerminateSignalReceived;
 
 		bool bEpoll;
 		int epfd; // Epoll file-descriptor

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -96,6 +96,7 @@ extern "C" {
 	void evma_set_max_timer_count (int);
 	void evma_setuid_string (const char *username);
 	void evma_stop_machine();
+	void evma_graceful_stop_machine();
 	float evma_get_heartbeat_interval();
 	int evma_set_heartbeat_interval(float);
 

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -730,6 +730,16 @@ static VALUE t_stop (VALUE self)
 	return Qnil;
 }
 
+/***************
+t_graceful_stop
+***************/
+
+static VALUE t_graceful_stop (VALUE self)
+{
+	evma_graceful_stop_machine();
+	return Qnil;
+}
+
 /******************
 t_signal_loopbreak
 ******************/
@@ -1206,6 +1216,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "read_keyboard", (VALUE(*)(...))t_read_keyboard, 0);
 	rb_define_module_function (EmModule, "release_machine", (VALUE(*)(...))t_release_machine, 0);
 	rb_define_module_function (EmModule, "stop", (VALUE(*)(...))t_stop, 0);
+	rb_define_module_function (EmModule, "graceful_stop", (VALUE(*)(...))t_graceful_stop, 0);
 	rb_define_module_function (EmModule, "signal_loopbreak", (VALUE(*)(...))t_signal_loopbreak, 0);
 	rb_define_module_function (EmModule, "library_type", (VALUE(*)(...))t_library_type, 0);
 	rb_define_module_function (EmModule, "set_timer_quantum", (VALUE(*)(...))t_set_timer_quantum, 1);


### PR DESCRIPTION
EventMachine_t::ScheduleHalt() currently will break out of the main event loop even if there is data that still remains to be written to sockets. The new method ScheduleGracefulHalt schedules a close of all open sockets and waits until they have closed to actually exit.

This behavior can be seen with a very simple server: https://gist.github.com/1283144

The server replies to each message the client sends, but the client never actually receives the message when stop is called instead of graceful_stop.

```
andy@zara:~$ nc localhost 8081
Hello!
hi  
Received 3 bytes
graceful_stop
Received 14 bytes
andy@zara:~$ 
```

```
andy@zara:~$ nc localhost 8081
Hello!
hi
Received 3 bytes
stop
andy@zara:~$ 
```
