### PR TITLE
Add dynamic environments to callbacks

### DIFF
--- a/ext/binder.cpp
+++ b/ext/binder.cpp
@@ -22,6 +22,7 @@ See the file COPYING for complete licensing information.
 #define DEV_URANDOM "/dev/urandom"
 
 
+void register_signature(unsigned long num);
 map<unsigned long, Bindable_t*> Bindable_t::BindingBag;
 
 
@@ -33,6 +34,7 @@ unsigned long Bindable_t::CreateBinding()
 {
 	static unsigned long num = 0;
 	while(BindingBag[++num]);
+	register_signature(num);
 	return num;
 }
 


### PR DESCRIPTION
This is a pretty alpha patch, but I'm curious whether anyone is interested in this functionality.

My main use-case is for something like the following: an HTTP request is received by an EM server. A series of callbacks happen as backend services are called. An exception is raised in one of them, which bubbles into the global error_handler. At this point, the error_handler would ideally serve a 500 to that request, but it doesn't have enough information to know which pending HTTP request has errored out.

This patch would allow the programmer to store the HTTP request in a dynamic environment, which is accessible from within the error_handler.
