### PR TITLE
em/version.rb:2: warning: already initialized constant VERSION

### DIFF
--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/em/version', __FILE__)
+$:.unshift File.expand_path("../lib", __FILE__)
+require "em/version"
+
 
 Gem::Specification.new do |s|
   s.name = 'eventmachine'


### PR DESCRIPTION
When I am using ruby 1.8.7 (2011-06-30 patchlevel 352) [x86_64-linux] and I am using bundler to require eventmachine, I get this error:

```
gems/ruby/1.8/bundler/gems/eventmachine-3c8ea2ed3d81/lib/em/version.rb:2: warning: already initialized constant VERSION
```

I traced out the places where `em/version.rb` is `require`d and it was in two places: bundler loading the gemspec, and then bundler requiring the gem.

The issue is that the gemspec loads the version like this:

``` ruby
require File.expand_path('../lib/em/version', __FILE__)
```

Which evaluates to the full system path to the version file. But bundler requires `em/version`. Ruby 1.8.7 does not realized it has already been `require`d and so it loads the file again.

It is my understanding that ruby 1.9.2's `require` is smarter, but in 1.8.7 this outputs a constant warning.

I borrowed this solution from the Asquera/vagrant project: https://github.com/Asquera/vagrant/commit/b26d588f74d9f524832cbf822bed15eccbd48b4c

The gem builds and tests pass except the sockopt test which is failing because I don't have permission to set sockopts on my system and I'm too dumb to figure that out right now.

xoxo @ngauthier
