### PR TITLE
Correctly pass error to `unbind` on connection handler

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1414,7 +1414,7 @@ module EventMachine
     if opcode == ConnectionUnbound
       if c = @conns.delete( conn_binding )
         begin
-          if c.original_method(:unbind).arity == 1
+          if c.original_method(:unbind).arity != 0
             c.unbind(data == 0 ? nil : EventMachine::ERRNOS[data])
           else
             c.unbind


### PR DESCRIPTION
To check if a method accepts at least 1 argument, it's better to check `arity != 0`. Checking `arity == 1` is wrong since the first argument may be optional, in which case arity will be -1.
