### PR TITLE
Test Unit for IPv6

### DIFF
--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -1,0 +1,90 @@
+require 'em_test_helper'
+require 'socket'
+
+class TestIPv4 < Test::Unit::TestCase
+
+  begin
+    socket = Addrinfo.udp("1.2.3.4", 1).connect
+    @@local_ipv4 = socket.local_address.ip_address
+    socket.close
+
+    # Tries to connect to www.google.com port 80 via TCP.
+    # Timeout in 2 seconds.
+    def test_ipv4_tcp_client
+      conn = nil
+      setup_timeout(2)
+      
+      EM.run do
+        conn = EM::connect("www.google.es", 80) do |c|
+          def c.connected
+            @connected
+          end
+          
+          def c.connection_completed
+            @connected = true
+            EM.stop
+          end
+        end
+      end
+      
+      assert conn.connected
+    end
+
+    # Runs a TCP server in the local IPv4 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv4_tcp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+      
+      EM.run do
+        EM::start_server(@@local_ipv4, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end          
+        end
+
+        EM::connect(@@local_ipv4, @local_port) do |c|
+          c.send_data "ipv4/tcp"
+        end
+      end
+
+      assert_equal "ipv4/tcp", @@received_data
+    end
+
+    # Runs a UDP server in the local IPv4 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv4_udp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+
+      EM.run do
+        EM::open_datagram_socket(@@local_ipv4, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end
+        end
+
+        EM::open_datagram_socket(@@local_ipv4, next_port) do |c|
+          c.send_datagram "ipv4/udp", @@local_ipv4, @local_port
+        end
+      end
+
+      assert_equal "ipv4/udp", @@received_data
+    end
+
+
+  rescue => e
+    warn "cannot autodiscover local IPv4 (#{e.class}: #{e.message}), skipping tests in #{__FILE__}"
+
+    # Because some rubies will complain if a TestCase class has no tests
+    def test_ipv4_unavailable
+      assert true
+    end
+
+  end
+
+end

--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -76,6 +76,44 @@ class TestIPv4 < Test::Unit::TestCase
       assert_equal "ipv4/udp", @@received_data
     end
 
+    # Try to connect via TCP to an invalid IPv4. EM.connect should raise
+    # EM::ConnectionError.
+    def test_tcp_connect_to_invalid_ipv4
+      invalid_ipv4 = "9.9:9"
+
+      EM.run do
+        begin
+          error = nil
+          EM.connect(invalid_ipv4, 1234)
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
+    # Try to send a UDP datagram to an invalid IPv4. EM.send_datagram should raise
+    # EM::ConnectionError.
+    def test_udp_send_datagram_to_invalid_ipv4
+      invalid_ipv4 = "9.9:9"
+
+      EM.run do
+        begin
+          error = nil
+          EM.open_datagram_socket(@@local_ipv4, next_port) do |c|
+            c.send_datagram "hello", invalid_ipv4, 1234
+          end
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
 
   rescue => e
     warn "cannot autodiscover local IPv4 (#{e.class}: #{e.message}), skipping tests in #{__FILE__}"

--- a/tests/test_ipv6.rb
+++ b/tests/test_ipv6.rb
@@ -1,0 +1,90 @@
+require 'em_test_helper'
+require 'socket'
+
+class TestIPv6 < Test::Unit::TestCase
+
+  begin
+    socket = Addrinfo.udp("2001::1", 1).connect
+    @@local_ipv6 = socket.local_address.ip_address
+    socket.close
+
+    # Tries to connect to ipv6.google.com port 80 via TCP.
+    # Timeout in 2 seconds.
+    def test_ipv6_tcp_client
+      conn = nil
+      setup_timeout(2)
+      
+      EM.run do
+        conn = EM::connect("2a00:1450:4001:c01::93", 80) do |c|
+          def c.connected
+            @connected
+          end
+          
+          def c.connection_completed
+            @connected = true
+            EM.stop
+          end
+        end
+      end
+      
+      assert conn.connected
+    end
+
+    # Runs a TCP server in the local IPv6 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv6_tcp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+      
+      EM.run do
+        EM::start_server(@@local_ipv6, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end          
+        end
+
+        EM::connect(@@local_ipv6, @local_port) do |c|
+          c.send_data "ipv6/tcp"
+        end
+      end
+
+      assert_equal "ipv6/tcp", @@received_data
+    end
+
+    # Runs a UDP server in the local IPv6 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv6_udp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+
+      EM.run do
+        EM::open_datagram_socket(@@local_ipv6, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end
+        end
+
+        EM::open_datagram_socket(@@local_ipv6, next_port) do |c|
+          c.send_datagram "ipv6/udp", @@local_ipv6, @local_port
+        end
+      end
+
+      assert_equal "ipv6/udp", @@received_data
+    end
+
+
+  rescue => e
+    warn "cannot autodiscover local IPv6 (#{e.class}: #{e.message}), skipping tests in #{__FILE__}"
+
+    # Because some rubies will complain if a TestCase class has no tests
+    def test_ipv6_unavailable
+      assert true
+    end
+
+  end
+
+end

--- a/tests/test_ipv6.rb
+++ b/tests/test_ipv6.rb
@@ -10,7 +10,7 @@ class TestIPv6 < Test::Unit::TestCase
 
     # Tries to connect to ipv6.google.com port 80 via TCP.
     # Timeout in 2 seconds.
-    def _test_ipv6_tcp_client
+    def test_ipv6_tcp_client
       conn = nil
       setup_timeout(4)
 

--- a/tests/test_ipv6.rb
+++ b/tests/test_ipv6.rb
@@ -10,23 +10,23 @@ class TestIPv6 < Test::Unit::TestCase
 
     # Tries to connect to ipv6.google.com port 80 via TCP.
     # Timeout in 2 seconds.
-    def test_ipv6_tcp_client
+    def _test_ipv6_tcp_client
       conn = nil
-      setup_timeout(2)
-      
+      setup_timeout(4)
+
       EM.run do
         conn = EM::connect("2a00:1450:4001:c01::93", 80) do |c|
           def c.connected
             @connected
           end
-          
+
           def c.connection_completed
             @connected = true
             EM.stop
           end
         end
       end
-      
+
       assert conn.connected
     end
 
@@ -36,16 +36,16 @@ class TestIPv6 < Test::Unit::TestCase
       @@received_data = nil
       @local_port = next_port
       setup_timeout(2)
-      
+
       EM.run do
-        EM::start_server(@@local_ipv6, @local_port) do |s|
+        EM.start_server(@@local_ipv6, @local_port) do |s|
           def s.receive_data data
             @@received_data = data
             EM.stop
-          end          
+          end
         end
 
-        EM::connect(@@local_ipv6, @local_port) do |c|
+        EM.connect(@@local_ipv6, @local_port) do |c|
           c.send_data "ipv6/tcp"
         end
       end
@@ -61,19 +61,57 @@ class TestIPv6 < Test::Unit::TestCase
       setup_timeout(2)
 
       EM.run do
-        EM::open_datagram_socket(@@local_ipv6, @local_port) do |s|
+        EM.open_datagram_socket(@@local_ipv6, @local_port) do |s|
           def s.receive_data data
             @@received_data = data
             EM.stop
           end
         end
 
-        EM::open_datagram_socket(@@local_ipv6, next_port) do |c|
+        EM.open_datagram_socket(@@local_ipv6, next_port) do |c|
           c.send_datagram "ipv6/udp", @@local_ipv6, @local_port
         end
       end
 
       assert_equal "ipv6/udp", @@received_data
+    end
+
+    # Try to connect via TCP to an invalid IPv6. EM.connect should raise
+    # EM::ConnectionError.
+    def test_tcp_connect_to_invalid_ipv6
+      invalid_ipv6 = "1:A"
+
+      EM.run do
+        begin
+          error = nil
+          EM.connect(invalid_ipv6, 1234)
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
+    # Try to send a UDP datagram to an invalid IPv6. EM.send_datagram should raise
+    # EM::ConnectionError.
+    def test_udp_send_datagram_to_invalid_ipv6
+      invalid_ipv6 = "1:A"
+
+      EM.run do
+        begin
+          error = nil
+          EM.open_datagram_socket(@@local_ipv6, next_port) do |c|
+            c.send_datagram "hello", invalid_ipv6, 1234
+          end
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
     end
 
 

--- a/tests/test_udp.rb
+++ b/tests/test_udp.rb
@@ -1,0 +1,33 @@
+require 'em_test_helper'
+
+class TestUDP < Test::Unit::TestCase
+
+  # Open a UDP socket listening in 127.0.0.1 and tries to send a UDP datagram to IP
+  # 1.2.3.4 (so no network route). Currently it makes EM to close the UDP socket.
+  #   See: https://github.com/eventmachine/eventmachine/issues/276
+  def test_udp_no_route
+    conn = nil
+    @@udp_socket_alive = false
+    @@udp_socket_unbind_cause = nil
+
+    EM.run do
+
+      conn = EM::open_datagram_socket("127.0.0.1", next_port, EM::Connection) do |c|
+        def c.unbind cause=nil
+          @@udp_socket_unbind_cause = cause
+          EM.stop
+        end
+
+        c.send_datagram "no-route", "1.2.3.4", 5555
+        EM.add_timer(0.2) do
+          @@udp_socket_alive = true  unless c.error?
+          EM.stop
+        end
+      end
+
+    end
+
+    assert @@udp_socket_alive, "UDP socket was killed (unbind cause: #{@@udp_socket_unbind_cause})"
+  end
+
+end


### PR DESCRIPTION
Test unit for testing IPv6 under TCP and UDP. The test unit checks both EM client and EM server.

For the test unit to work, a local IPv6 is required in the computer where the test runs. In Linux I use Miredo (which also runs in Windows and MacOSX): http://www.remlab.net/miredo