### PR TITLE
Indent problem in server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,20 @@ For an introduction to EventMachine, check out:
 
 Here's a fully-functional echo server written with EventMachine:
 
-     require 'eventmachine'
+    require 'eventmachine'
 
-     module EchoServer
-       def post_init
-         puts "-- someone connected to the echo server!"
-       end
+    module EchoServer
+      def post_init
+        puts "-- someone connected to the echo server!"
+      end
 
-       def receive_data data
-         send_data ">>>you sent: #{data}"
-         close_connection if data =~ /quit/i
-       end
+      def receive_data data
+        send_data ">>>you sent: #{data}"
+        close_connection if data =~ /quit/i
+      end
 
-       def unbind
-         puts "-- someone disconnected from the echo server!"
+      def unbind
+        puts "-- someone disconnected from the echo server!"
       end
     end
 


### PR DESCRIPTION
A few lines in the "echo server" example in `README.md` had one extra whitespace caracter.
