### PR TITLE
Making outbound data queue size available to user

### DIFF
--- a/java/src/com/rubyeventmachine/EmReactor.java
+++ b/java/src/com/rubyeventmachine/EmReactor.java
@@ -437,6 +437,10 @@ public class EmReactor {
 		sendData (sig, ByteBuffer.wrap(data));
 	}
 
+        public int getOutboundDataSize(long sig) {
+               return Connections.get(sig).getOutboundDataSize();
+        }
+
 	public void setCommInactivityTimeout (long sig, long mills) {
 		Connections.get(sig).setCommInactivityTimeout (mills);
 	}

--- a/java/src/com/rubyeventmachine/EventableChannel.java
+++ b/java/src/com/rubyeventmachine/EventableChannel.java
@@ -57,6 +57,8 @@ public interface EventableChannel {
 	
 	public boolean writeOutboundData() throws IOException;
 
+	public int getOutboundDataSize();
+
 	public void setCommInactivityTimeout (long seconds);
 
 	public Object[] getPeerName();

--- a/java/src/com/rubyeventmachine/EventableDatagramChannel.java
+++ b/java/src/com/rubyeventmachine/EventableDatagramChannel.java
@@ -169,6 +169,10 @@ public class EventableDatagramChannel implements EventableChannel {
 		return (bCloseScheduled && outboundQ.isEmpty()) ? false : true;
 	}
 
+	public int getOutboundDataSize() {
+	        throw new UnsupportedOperationException();
+	}
+
 	public void setCommInactivityTimeout (long seconds) {
 		// TODO
 		System.out.println ("DATAGRAM: SET COMM INACTIVITY UNIMPLEMENTED " + seconds);

--- a/java/src/com/rubyeventmachine/EventableSocketChannel.java
+++ b/java/src/com/rubyeventmachine/EventableSocketChannel.java
@@ -156,6 +156,14 @@ public class EventableSocketChannel implements EventableChannel {
 		channel = null;
 	}
 	
+	public int getOutboundDataSize() {
+	       int size = 0;
+	       for (ByteBuffer b : outboundQ) {
+	               size += b.remaining();
+	       }
+	       return size;
+	}
+
 	public void scheduleOutboundData (ByteBuffer bb) {
 		if (!bCloseScheduled && bb.remaining() > 0) {
 			if (sslEngine != null) {

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -222,6 +222,10 @@ module EventMachine
       EventMachine::send_data @signature, data, size
     end
 
+    def get_outbound_data_size
+      EventMachine::get_outbound_data_size @signature
+    end
+
     # Returns true if the connection is in an error state, false otherwise.
     # In general, you can detect the occurrence of communication errors or unexpected
     # disconnection by the remote peer by handing the #unbind method. In some cases, however,

--- a/lib/jeventmachine.rb
+++ b/lib/jeventmachine.rb
@@ -116,6 +116,9 @@ module EventMachine
   def self.send_data sig, data, length
     @em.sendData sig, data.to_java_bytes
   end
+  def self.get_outbound_data_size sig
+    @em.getOutboundDataSize sig
+  end
   def self.send_datagram sig, data, length, address, port
     @em.sendDatagram sig, data, length, address, port
   end


### PR DESCRIPTION
Hello,

When using eventmachine as a TCP server, it can be useful to know when the network buffers have filled up and we are starting to queue inside of the EventableSocketChannel (so you can take action and close the socket as necessary, to avoid overflowing the heap and crashing your process).  The C ruby version has a way of accessing this internal queue, so I've added it to the jruby version.

Thanks :)
--becky