### PR TITLE
Reimplement Queue to avoid shift/push performance problem

### DIFF
--- a/lib/em/queue.rb
+++ b/lib/em/queue.rb
@@ -17,7 +17,8 @@ module EventMachine
   #
   class Queue
     def initialize
-      @items = []
+      @sink  = []
+      @drain = []
       @popq  = []
     end
 
@@ -29,10 +30,14 @@ module EventMachine
     def pop(*a, &b)
       cb = EM::Callback(*a, &b)
       EM.schedule do
-        if @items.empty?
+        if @drain.empty?
+          @drain = @sink
+          @sink = []
+        end
+        if @drain.empty?
           @popq << cb
         else
-          cb.call @items.shift
+          cb.call @drain.shift
         end
       end
       nil # Always returns nil
@@ -43,8 +48,12 @@ module EventMachine
     # next reactor tick.
     def push(*items)
       EM.schedule do
-        @items.push(*items)
-        @popq.shift.call @items.shift until @items.empty? || @popq.empty?
+        @sink.push(*items)
+        unless @popq.empty?
+          @drain = @sink
+          @sink = []
+          @popq.shift.call @drain.shift until @drain.empty? || @popq.empty?
+        end
       end
     end
     alias :<< :push
@@ -52,13 +61,13 @@ module EventMachine
     # @return [Boolean]
     # @note This is a peek, it's not thread safe, and may only tend toward accuracy.
     def empty?
-      @items.empty?
+      @drain.empty? && @sink.empty?
     end
 
     # @return [Integer] Queue size
     # @note This is a peek, it's not thread safe, and may only tend toward accuracy.
     def size
-      @items.size
+      @drain.size + @sink.size
     end
 
     # @return [Integer] Waiting size

--- a/tests/test_queue.rb
+++ b/tests/test_queue.rb
@@ -47,4 +47,18 @@ class TestEMQueue < Test::Unit::TestCase
     EM.run { EM.next_tick { EM.stop } }
     assert_equal many, q.num_waiting
   end
+
+  def test_big_queue
+    EM.run do
+      q = EM::Queue.new
+      2000.times do |i|
+        q.push(*0..1000)
+        q.pop { |v| assert_equal v, i % 1001 }
+      end
+      q.pop do
+        assert_equal 1_999_999, q.size
+        EM.stop
+      end
+    end
+  end
 end


### PR DESCRIPTION
The existing EM::Queue implementation uses push and shift to shuffle the queued items through an array. Unfortunately, a shift followed by a push has linear time complexity in the size of the array, making queue operations very expensive for long queues.

The patch replaces the @items array with two separate arrays @sink for pushing elements into it and @drain for shifting out elements. This ensures that both push and shift get amortized constant time complexity.

In addition, the patch introduces a test that demonstrates the performance issues. For me, the new test passes with both Queue implementations, but takes minutes with the old implementation and much less than a second with the new implementation.