### PR TITLE
Stomp content-length header should be in bytes

### DIFF
--- a/lib/em/protocols/stomp.rb
+++ b/lib/em/protocols/stomp.rb
@@ -104,12 +104,15 @@ module EventMachine
 
       # @private
       def send_frame verb, headers={}, body=""
+        body = body.to_s
         ary = [verb, "\n"]
+        body_bytesize = body.bytesize if body.respond_to? :bytesize
+        body_bytesize ||= body.size
         headers.each {|k,v| ary << "#{k}:#{v}\n" }
-        ary << "content-length: #{body.to_s.length}\n"
+        ary << "content-length: #{body_bytesize}\n"
         ary << "content-type: text/plain; charset=UTF-8\n" unless headers.has_key? 'content-type'
         ary << "\n"
-        ary << body.to_s
+        ary << body
         ary << "\0"
         send_data ary.join
       end

--- a/tests/test_stomp.rb
+++ b/tests/test_stomp.rb
@@ -1,0 +1,37 @@
+require 'em_test_helper'
+
+class TestStomp < Test::Unit::TestCase
+  CONTENT_LENGTH_REGEX = /^content-length: (\d+)$/
+
+  def bytesize(str)
+    str = str.to_s
+    size = str.bytesize if str.respond_to?(:bytesize) # bytesize added in 1.9
+    size || str.size
+  end
+
+  def test_content_length_in_bytes
+    connection = Object.new
+    connection.instance_eval do 
+      extend EM::P::Stomp
+
+      def last_sent_content_length
+        @sent && Integer(@sent[CONTENT_LENGTH_REGEX, 1])
+      end
+
+      def send_data(string)
+        @sent = string
+      end
+    end
+
+    queue = "queue"
+    failure_message = "header content-length is not the byte size of last sent body"
+
+    body = "test"
+    connection.send queue, body
+    assert_equal bytesize(body), connection.last_sent_content_length, failure_message
+
+    body = "test\u221A"
+    connection.send queue, body
+    assert_equal bytesize(body), connection.last_sent_content_length, failure_message
+  end
+end


### PR DESCRIPTION
In 1.9.x String#size doesn't return the number of bytes, but the number of characters. The Stomp protocol wants the number of bytes in the content-length header. Using String#size falls down when there are multibyte characters. I updated the header to use bytesize when it's available matching the form in [EM::Connection#send_data](https://github.com/eventmachine/eventmachine/blob/master/lib/em/connection.rb#L324).

> It is recommended that SEND frames include a content-length header which is a byte count for the length of the message body." 
> 
> http://docs.codehaus.org/display/STOMP/Protocol

I wasn't sure the best way to write a test for it. I'd be happy to update the test if given advice.
