### PR TITLE
Add EventMachine.defers_finished?

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1048,7 +1048,7 @@ module EventMachine
   # callbacks have been fired.
   #
   def self.defers_finished?
-    return false unless @all_threads_spawned
+    return false if @threadpool and !@all_threads_spawned
     return false if @threadqueue and not @threadqueue.empty?
     return false if @resultqueue and not @resultqueue.empty?
     return false if @threadpool and @threadqueue.num_waiting != @threadpool.size


### PR DESCRIPTION
This method can be useful when deciding when to stop EventMachine. For example, after thousands of connections established by EventMachine and each connection could defer some actions, this method reliably tells whether it's safe to stop EventMachine or not. It could be used repeatedly after the last connection has unbound.

Otherwise it's not easy to decide when it's safe to stop EventMachine, even after the last connection has unbound. And it's not safe to stop EventMachine right away because it'll #kill the running threads in the threadpool.
