### PR TITLE
fix EM.system when unicode characters used

### DIFF
--- a/lib/em/processes.rb
+++ b/lib/em/processes.rb
@@ -114,7 +114,7 @@ module EventMachine
     init = args.pop if args.last.is_a? Proc
 
     # merge remaining arguments into the command
-    cmd = ([cmd] + args.map{|a|a.to_s.dump}).join(' ')
+    cmd = [cmd, *args]
 
     EM.get_subprocess_pid(EM.popen(cmd, SystemCmd, cb) do |c|
       init[c] if init

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1156,7 +1156,12 @@ module EventMachine
     # Perhaps misnamed since the underlying function uses socketpair and is full-duplex.
 
     klass = klass_from_handler(Connection, handler, *args)
-    w = Shellwords::shellwords( cmd )
+    w = case cmd
+        when Array
+          cmd
+        when String
+          Shellwords::shellwords( cmd )
+        end
     w.unshift( w.first ) if w.first
     s = invoke_popen( w )
     c = klass.new s, *args

--- a/tests/test_system.rb
+++ b/tests/test_system.rb
@@ -1,0 +1,28 @@
+# coding: utf-8
+require 'em_test_helper'
+
+class TestSystem < Test::Unit::TestCase
+  def setup
+    @filename = File.expand_path("../я манал dump.txt", __FILE__)
+    @test_data = 'a' * 100
+    File.open(@filename, 'w'){|f| f.write(@test_data)}
+  end
+
+  def test_system
+    result = nil
+    status = nil
+    EM.run {
+      EM.system('cat', @filename){|out, state|
+        result = out
+        status = state.exitstatus
+        EM.stop
+      }
+    }
+    assert_equal(0, status)
+    assert_equal(@test_data, result)
+  end
+
+  def teardown
+    File.unlink(@filename)
+  end
+end


### PR DESCRIPTION
Since EventMachine C++ core already use execvp, there is no need to call "dump" in EM.system. In fact, using "dump" breaks international language arguments
