### PR TITLE
store path inside of FileWatch.new

### DIFF
--- a/lib/em/file_watch.rb
+++ b/lib/em/file_watch.rb
@@ -17,6 +17,26 @@ module EventMachine
     Cmoved = 'moved'.freeze
 
 
+    # Override .new so subclasses don't have to call super and can ignore
+    # connection-specific arguments
+    #
+    # @private
+    def self.new(sig, path, *args)
+      allocate.instance_eval do
+        # Store signature and path
+        @signature = sig
+        @path = path
+
+        # Call a superclass's #initialize if it has one
+        initialize(*args)
+
+        # post initialize callback
+        post_init
+
+        self
+      end
+    end
+
     # @private
     def receive_data(data)
       case data

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1275,9 +1275,7 @@ module EventMachine
     klass = klass_from_handler(FileWatch, handler, *args)
 
     s = EM::watch_filename(filename)
-    c = klass.new s, *args
-    # we have to set the path like this because of how Connection.new works
-    c.instance_variable_set("@path", filename)
+    c = klass.new s, filename, *args
     @conns[s] = c
     block_given? and yield c
     c


### PR DESCRIPTION
Store path before constructor called, so that we are not forced to pass it twice for custom class
