### PR TITLE
Fix to prevent event machine from being stopped when catching an exception in unbind.

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -415,6 +415,15 @@ extern "C" void evma_stop_machine()
 	EventMachine->ScheduleHalt();
 }
 
+/*****************
+evma_stopping
+*****************/
+
+extern "C" bool evma_stopping()
+{
+	ensure_eventmachine("evma_stopping");
+	return EventMachine->Stopping();
+}
 
 /**************
 evma_start_tls

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -189,7 +189,10 @@ void EventMachine_t::ScheduleHalt()
 	bTerminateSignalReceived = true;
 }
 
-
+bool EventMachine_t::Stopping()
+{
+    return bTerminateSignalReceived;
+}
 
 /*******************************
 EventMachine_t::SetTimerQuantum

--- a/ext/em.h
+++ b/ext/em.h
@@ -76,6 +76,7 @@ class EventMachine_t
 
 		void Run();
 		void ScheduleHalt();
+		bool Stopping();
 		void SignalLoopBreaker();
 		const unsigned long InstallOneshotTimer (int);
 		const unsigned long ConnectToServer (const char *, int, const char *, int);

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -97,6 +97,7 @@ extern "C" {
 	void evma_set_max_timer_count (int);
 	void evma_setuid_string (const char *username);
 	void evma_stop_machine();
+	bool evma_stopping();
 	float evma_get_heartbeat_interval();
 	int evma_set_heartbeat_interval(float);
 

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -978,6 +978,23 @@ static VALUE t__ssl_p (VALUE self)
   #endif
 }
 
+/********
+t_stopping
+********/
+
+static VALUE t_stopping ()
+{
+    if (evma_stopping())
+    {
+        return Qtrue;
+    }
+    else
+    {
+        return Qfalse;
+    }
+
+}
+
 
 /****************
 t_send_file_data
@@ -1277,6 +1294,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "kqueue?", (VALUE(*)(...))t__kqueue_p, 0);
 
 	rb_define_module_function (EmModule, "ssl?", (VALUE(*)(...))t__ssl_p, 0);
+	rb_define_module_function(EmModule, "stopping?",(VALUE(*)(...))t_stopping, 0);
 
 	rb_define_method (EmConnection, "get_outbound_data_size", (VALUE(*)(...))conn_get_outbound_data_size, 0);
 	rb_define_method (EmConnection, "associate_callback_target", (VALUE(*)(...))conn_associate_callback_target, 1);

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -66,6 +66,11 @@ module EventMachine
     def release_machine
     end
 
+
+    def stopping?
+      return Reactor.instance.stop_scheduled
+    end
+
     # @private
     def stop
       Reactor.instance.stop
@@ -273,7 +278,7 @@ module EventMachine
 
     HeartbeatInterval = 2
 
-    attr_reader :current_loop_time
+    attr_reader :current_loop_time, :stop_scheduled
 
     def initialize
       initialize_for_run


### PR DESCRIPTION
Eventmachine _IS_ stopped when an exception is raised when the reactor is already being stopped.
