### PR TITLE
Fix to prevent event machine from stopping when a raise is done in an unbind.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ pkg
 rdoc
 Makefile
 
+*.idea
 *.bundle
 *.dll
 *.so

--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -415,6 +415,15 @@ extern "C" void evma_stop_machine()
 	EventMachine->ScheduleHalt();
 }
 
+/*****************
+evma_stopping
+*****************/
+
+extern "C" bool evma_stopping()
+{
+	ensure_eventmachine("evma_stopping");
+	return EventMachine->Stopping();
+}
 
 /**************
 evma_start_tls

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -189,7 +189,10 @@ void EventMachine_t::ScheduleHalt()
 	bTerminateSignalReceived = true;
 }
 
-
+bool EventMachine_t::Stopping()
+{
+    return bTerminateSignalReceived;
+}
 
 /*******************************
 EventMachine_t::SetTimerQuantum

--- a/ext/em.h
+++ b/ext/em.h
@@ -76,6 +76,7 @@ class EventMachine_t
 
 		void Run();
 		void ScheduleHalt();
+		bool Stopping();
 		void SignalLoopBreaker();
 		const unsigned long InstallOneshotTimer (int);
 		const unsigned long ConnectToServer (const char *, int, const char *, int);

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -97,6 +97,7 @@ extern "C" {
 	void evma_set_max_timer_count (int);
 	void evma_setuid_string (const char *username);
 	void evma_stop_machine();
+	bool evma_stopping();
 	float evma_get_heartbeat_interval();
 	int evma_set_heartbeat_interval(float);
 

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -978,6 +978,23 @@ static VALUE t__ssl_p (VALUE self)
   #endif
 }
 
+/********
+t_stopping
+********/
+
+static VALUE t_stopping ()
+{
+    if (evma_stopping())
+    {
+        return Qtrue;
+    }
+    else
+    {
+        return Qfalse;
+    }
+
+}
+
 
 /****************
 t_send_file_data
@@ -1277,6 +1294,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "kqueue?", (VALUE(*)(...))t__kqueue_p, 0);
 
 	rb_define_module_function (EmModule, "ssl?", (VALUE(*)(...))t__ssl_p, 0);
+	rb_define_module_function(EmModule, "stopping?",(VALUE(*)(...))t_stopping, 0);
 
 	rb_define_method (EmConnection, "get_outbound_data_size", (VALUE(*)(...))conn_get_outbound_data_size, 0);
 	rb_define_method (EmConnection, "associate_callback_target", (VALUE(*)(...))conn_associate_callback_target, 1);

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -66,6 +66,11 @@ module EventMachine
     def release_machine
     end
 
+
+    def stopping?
+      return Reactor.instance.stop_scheduled
+    end
+
     # @private
     def stop
       Reactor.instance.stop
@@ -273,7 +278,7 @@ module EventMachine
 
     HeartbeatInterval = 2
 
-    attr_reader :current_loop_time
+    attr_reader :current_loop_time, :stop_scheduled
 
     def initialize
       initialize_for_run

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1441,9 +1441,13 @@ module EventMachine
             rescue Errno::EBADF, IOError
             end
           end
-        rescue
-          @wrapped_exception = $!
-          stop
+        rescue Exception => e
+          if stopping?
+            @wrapped_exception = $!
+            stop
+          else
+            raise e
+          end
         end
       elsif c = @acceptors.delete( conn_binding )
         # no-op

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -93,12 +93,25 @@ class TestBasic < Test::Unit::TestCase
     end
   end
 
-  def test_unbind_error
+  def test_unbind_error_during_stop
     assert_raises( UnbindError::ERR ) {
       EM.run {
         EM.start_server "127.0.0.1", @port
-        EM.connect "127.0.0.1", @port, UnbindError
+        EM.connect "127.0.0.1", @port, UnbindError do
+          EM.stop
+        end
       }
+    }
+  end
+
+  def test_unbind_error
+    EM.run {
+      EM.error_handler do |e|
+        assert(e.is_a?(UnbindError::ERR))
+        EM.stop
+      end
+      EM.start_server "127.0.0.1", @port
+      EM.connect "127.0.0.1", @port, UnbindError
     }
   end
 


### PR DESCRIPTION
Currently, eventmachine will stop when a handler raises an exception in its unbind method. This is an intended feature for when the eventmachine reactor is being stopped, as it is undesirable to keep the reactor running when exceptions are being thrown while connections are being unbound. 

This however does cause issues when exceptions are raised in unbinds when eventmachine is not being stopped.

This fix adds a method to the eventmachine cpp module which enables you to check wether or not the reactor is being stopped. Consequently the raising of an exception during an unbind will only resort in a reactor stop if it was already being stopped.

We implemented this locally for a project, tested it and it seems to be working well. Granted, this is only necessary if handler code implements exceptions in the unbind method.

Tests have been added, and the existing ones all still pass.