### PR TITLE
Allow binding to non local address if supported

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1120,6 +1120,14 @@ const unsigned long EventMachine_t::ConnectToServer (const char *bind_addr, int 
 	setsockopt (sd, SOL_SOCKET, SO_REUSEADDR, (char*) &one, sizeof(one));
 
 	if (bind_addr) {
+	  
+#if defined(SO_BINDANY)
+		if( getuid() == 0 ){
+			int on = 1;
+			setsockopt(sd, SOL_SOCKET, SO_BINDANY, &on, sizeof(on));
+		}
+#endif
+	  
 		int bind_to_size, bind_to_family;
 		struct sockaddr *bind_to = name2address (bind_addr, bind_port, &bind_to_family, &bind_to_size);
 		if (!bind_to) {
@@ -1597,6 +1605,13 @@ const unsigned long EventMachine_t::OpenDatagramSocket (const char *address, int
 
 
 	if (address && *address) {
+#if defined(SO_BINDANY)    
+		if( getuid() == 0 ){
+			int on = 1;
+			setsockopt(sd, SOL_SOCKET, SO_BINDANY, &on, sizeof(on));
+		}
+#endif
+
 		sin.sin_addr.s_addr = inet_addr (address);
 		if (sin.sin_addr.s_addr == INADDR_NONE) {
 			hostent *hp = gethostbyname ((char*)address); // Windows requires the cast.


### PR DESCRIPTION
is there any chance this could get merged ? I can update documentation and maybe improve the patch but not unless it can get merged.

What it does is allowing to bind to any address (as far as I know only FreeBSD and OpenBSD support this):

``` ruby
EM.bind_connect('1.2.3.4', nil, '192.168.0.1', 8000, Handler)
EM::open_datagram_socket('1.2.3.4', nil, Handler)
```

The main use is writing transparent proxy as you can bind to any non local address with this patch (only enabled if your are root and currently only for OpenBSD).
