### PR TITLE
Avoid dangerous rb_raise() usage.

### DIFF
--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -507,7 +507,7 @@ static VALUE t_connect_server (VALUE self, VALUE server, VALUE port)
 			rb_raise (EM_eConnectionError, "no connection");
 		return ULONG2NUM (f);
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eConnectionError, e.what());
+		rb_raise (EM_eConnectionError, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -528,7 +528,7 @@ static VALUE t_bind_connect_server (VALUE self, VALUE bind_addr, VALUE bind_port
 			rb_raise (EM_eConnectionError, "no connection");
 		return ULONG2NUM (f);
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eConnectionError, e.what());
+		rb_raise (EM_eConnectionError, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -848,7 +848,7 @@ static VALUE t_watch_filename (VALUE self, VALUE fname)
 	try {
 		return ULONG2NUM(evma_watch_filename(StringValuePtr(fname)));
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eUnsupported, e.what());
+		rb_raise (EM_eUnsupported, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -874,7 +874,7 @@ static VALUE t_watch_pid (VALUE self, VALUE pid)
 	try {
 		return ULONG2NUM(evma_watch_pid(NUM2INT(pid)));
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eUnsupported, e.what());
+		rb_raise (EM_eUnsupported, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -1074,7 +1074,7 @@ static VALUE t_start_proxy (VALUE self, VALUE from, VALUE to, VALUE bufsize, VAL
 	try {
 		evma_start_proxy(NUM2ULONG (from), NUM2ULONG (to), NUM2ULONG(bufsize), NUM2ULONG(length));
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eConnectionError, e.what());
+		rb_raise (EM_eConnectionError, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -1089,7 +1089,7 @@ static VALUE t_stop_proxy (VALUE self, VALUE from)
 	try{
 		evma_stop_proxy(NUM2ULONG (from));
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eConnectionError, e.what());
+		rb_raise (EM_eConnectionError, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -1103,7 +1103,7 @@ static VALUE t_proxied_bytes (VALUE self, VALUE from)
 	try{
 		return ULONG2NUM(evma_proxied_bytes(NUM2ULONG (from)));
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eConnectionError, e.what());
+		rb_raise (EM_eConnectionError, "%s", e.what());
 	}
 	return Qnil;
 }
@@ -1128,7 +1128,7 @@ static VALUE t_get_idle_time (VALUE self, VALUE from)
 			return Qnil;
 		}
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eConnectionError, e.what());
+		rb_raise (EM_eConnectionError, "%s", e.what());
 	}
 	return Qnil;
 }


### PR DESCRIPTION
Passing a variable as the format string to rb_raise() is potentially dangerous
because the variable might contain a formatting sequence (e.g., "%s").
