### PR TITLE
Extract from buffer in edge case of multi-character delimiter

### DIFF
--- a/lib/em/buftok.rb
+++ b/lib/em/buftok.rb
@@ -70,10 +70,12 @@ class BufferedTokenizer
     # entities this go-around, return an empty array.
     return [] if entities.empty?
 
-    # At this point, we've hit a token, or potentially multiple tokens.  Now we can bring
+    # At this point, we've hit a token, or potentially multiple tokens. After merging 
+    # all the data, we must do one final extraction in the edge case
+    # that the delimiter has multiple characters. Now we can bring
     # together all the data we've buffered from earlier calls without hitting a token,
     # and add it to our list of discovered entities.
-    entities.unshift @input.join
+    entities = @input.join.split(@delimiter) + entities
 
     # Now that we've hit a token, joined the input buffer and added it to the entities
     # list, we can go ahead and clear the input buffer.  All of the segments that were


### PR DESCRIPTION
The BufferedTokenizer works great with single character delimiters, but with multi-character delimiter it doesn't address the edge case of extracting the delimiter out of the internal buffer. The original discussion as well as code examples of the edge case can be found in another pull request:

https://github.com/eventmachine/eventmachine/pull/338