### PR TITLE
in 1.9 String#[] returns character not a character code

### DIFF
--- a/lib/em/protocols/smtpserver.rb
+++ b/lib/em/protocols/smtpserver.rb
@@ -541,7 +541,7 @@ module EventMachine
           @state.delete :data
         else
           # slice off leading . if any
-          ln.slice!(0...1) if ln[0] == 46
+          ln.slice!(0...1) if ln[0] && ln[0].ord == 46
           @databuffer << ln
           if @databuffer.length > @@parms[:chunksize]
             receive_data_chunk @databuffer


### PR DESCRIPTION
I've faced a bug when a dot at the beginning of the line was duplicated.
That was caused by this line in SmtpServer#process_data_line:
ln.slice!(0...1) if ln[0] == 46
In 1.8 String#[] indeed returns a character code, but for 1.9 it simply returns a character (String#getbyte can be used instead)
For compatibility with 1.8.7 `String#start_with?` used instead
Update
`String#ord` used instead of `String#start_with?`
