### PR TITLE
use rb_wait_for_single_fd when present (ruby 1.9)

### DIFF
--- a/ext/em.h
+++ b/ext/em.h
@@ -22,6 +22,9 @@ See the file COPYING for complete licensing information.
 
 #ifdef BUILD_FOR_RUBY
   #include <ruby.h>
+  #ifdef HAVE_RB_WAIT_FOR_SINGLE_FD
+  #include <ruby/io.h>
+  #endif
   #define EmSelect rb_thread_select
 
   #if defined(HAVE_RBTRAP)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -73,6 +73,7 @@ add_define 'HAVE_WRITEV' if have_func('writev', 'sys/uio.h')
 
 have_func('rb_thread_check_ints')
 have_func('rb_time_new')
+have_func('rb_wait_for_single_fd')
 
 # Minor platform details between *nix and Windows:
 


### PR DESCRIPTION
rb_wait_for_single_fd could use poll (if present) instead of select
