### PR TITLE
Make PLAIN AUTH SMTP work with long username/passwords.

### DIFF
--- a/lib/em/protocols/smtpclient.rb
+++ b/lib/em/protocols/smtpclient.rb
@@ -271,7 +271,7 @@ module EventMachine
               psw = psw.call
             end
             #str = Base64::encode64("\0#{@args[:auth][:username]}\0#{psw}").chomp
-            str = ["\0#{@args[:auth][:username]}\0#{psw}"].pack("m").chomp
+            str = ["\0#{@args[:auth][:username]}\0#{psw}"].pack("m").gsub(/\n/, '')
             send_data "AUTH PLAIN #{str}\r\n"
             @responder = :receive_auth_response
           else


### PR DESCRIPTION
As it stands, the smtpclient protocol uses Array#pack to base64 encode data, which wraps the output at 60-characters (as you would when sending base64-encoded mail). However, the AUTH SMTP extension expects the initial authentication string to be a single line. 

This is a particular issue when using credentials for Amazon's simple email service, which tend to be quite long (>64 characters combined).

Is this okay to be merged as is, or is there anything else you'd need me to do first?
