### PR TITLE
mingw source builds fail due to `or` precedence

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -77,7 +77,7 @@ have_func('rb_time_new')
 # Minor platform details between *nix and Windows:
 
 if RUBY_PLATFORM =~ /(mswin|mingw|bccwin)/
-  GNU_CHAIN = ENV['CROSS_COMPILING'] or $1 == 'mingw'
+  GNU_CHAIN = ENV['CROSS_COMPILING'] || $1 == 'mingw'
   OS_WIN32 = true
   add_define "OS_WIN32"
 else

--- a/ext/fastfilereader/extconf.rb
+++ b/ext/fastfilereader/extconf.rb
@@ -17,7 +17,7 @@ add_define 'BUILD_FOR_RUBY'
 # Minor platform details between *nix and Windows:
 
 if RUBY_PLATFORM =~ /(mswin|mingw|bccwin)/
-  GNU_CHAIN = ENV['CROSS_COMPILING'] or $1 == 'mingw'
+  GNU_CHAIN = ENV['CROSS_COMPILING'] || $1 == 'mingw'
   OS_WIN32 = true
   add_define "OS_WIN32"
 else


### PR DESCRIPTION
Simple fix for `or` vs. `=` precedence bug.

Fix tested with ruby_1_9_3 and trunk on Win7 32bit using both mingw-based gcc 4.7.1 and mingw-w64 gcc 4.7.2 toolchains.
