### PR TITLE
Fix calling pause in post_init when epoll is enabled

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1447,7 +1447,8 @@ void AcceptorDescriptor::Read()
 			(*EventCallback) (GetBinding(), EM_CONNECTION_ACCEPTED, NULL, cd->GetBinding());
 		}
 		#ifdef HAVE_EPOLL
-		cd->GetEpollEvent()->events = EPOLLIN | (cd->SelectForWrite() ? EPOLLOUT : 0);
+		cd->GetEpollEvent()->events =
+		  (cd->SelectForRead() ? EPOLLIN : 0) | (cd->SelectForWrite() ? EPOLLOUT : 0);
 		#endif
 		assert (MyEventMachine);
 		MyEventMachine->Add (cd);


### PR DESCRIPTION
Previously calling pause in post_init did not stop receive_data from being called on the connection when epoll is enabled.

Fix this by only setting EPOLLIN in the new ConnectionDescriptor if SelectForRead is true.

If pause is called in post_init, SelectForRead will have become false during EventCallback.

I suspect kqueue has this same bug in AcceptorDescriptor::Read but I don't have a way to test this.
