### PR TITLE
Allow JRuby users to use pure ruby reactor

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1,8 +1,8 @@
-if RUBY_PLATFORM =~ /java/
+if defined?(EventMachine.library_type) and EventMachine.library_type == :pure_ruby
+  # assume 'em/pure_ruby' was loaded already
+elsif RUBY_PLATFORM =~ /java/
   require 'java'
   require 'jeventmachine'
-elsif defined?(EventMachine.library_type) and EventMachine.library_type == :pure_ruby
-  # assume 'em/pure_ruby' was loaded already
 else
   begin
     require 'rubyeventmachine'


### PR DESCRIPTION
I just reversed the order of the conditional load checks so that it's possible to use either reactor on jruby. 
