### PR TITLE
Fix a BIO leak when verifying SSL certificates or calling get_peer_cert.

### DIFF
--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -332,7 +332,7 @@ static VALUE t_get_peer_cert (VALUE self, VALUE signature)
 		BIO_get_mem_ptr(out, &buf);
 		ret = rb_str_new(buf->data, buf->length);
 		X509_free(cert);
-		BUF_MEM_free(buf);
+		BIO_free(out);
 	}
 	#endif
 

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -459,7 +459,7 @@ extern "C" int ssl_verify_wrapper(int preverify_ok, X509_STORE_CTX *ctx)
 
 	ConnectionDescriptor *cd = dynamic_cast <ConnectionDescriptor*> (Bindable_t::GetObject(binding));
 	result = (cd->VerifySslPeer(buf->data) == true ? 1 : 0);
-	BUF_MEM_free(buf);
+	BIO_free(out);
 
 	return result;
 }


### PR DESCRIPTION
You can verify this with a modification of the trivial `start_tls` example program. Prior to this patch, the following program's memory usage will grow unboundedly.

```
require 'eventmachine'

module Handler
  def post_init
    puts "Starting TLS"
    start_tls
  end

  def ssl_handshake_completed
    puts "Connected. Cert:"
    puts get_peer_cert
    loop { get_peer_cert }
  end

  def unbind
    EventMachine::stop_event_loop
  end
end

EventMachine.run do
  EventMachine.connect "mail.google.com", 443, Handler
end
```
