### PR TITLE
fix compilation for Ruby 2.0.0 in Windows x64

### DIFF
--- a/ext/project.h
+++ b/ext/project.h
@@ -94,7 +94,7 @@ typedef int SOCKET;
 #include <assert.h>
 
 typedef int socklen_t;
-typedef int pid_t;
+// typedef int pid_t;
 #endif
 
 #if !defined(_MSC_VER) || _MSC_VER > 1500


### PR DESCRIPTION
I commented out the typedef for pid_t in project.h:97
that is unecessary for windows as the type is already installed.
