### PR TITLE
Add support for EM.set_simultaneous_accept_count(<int>).

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -642,7 +642,6 @@ extern "C" int evma_get_max_timer_count()
 	return EventMachine_t::GetMaxTimerCount();
 }
 
-
 /************************
 evma_set_max_timer_count
 ************************/
@@ -659,6 +658,21 @@ extern "C" void evma_set_max_timer_count (int ct)
 		#endif
 	EventMachine_t::SetMaxTimerCount (ct);
 }
+
+/******************
+evma_get/set_simultaneous_accept_count
+******************/
+
+extern "C" void evma_set_simultaneous_accept_count (int count)
+{
+	EventMachine_t::SetSimultaneousAcceptCount(count);
+}
+
+extern "C" int evma_get_simultaneous_accept_count()
+{
+	return EventMachine_t::GetSimultaneousAcceptCount();
+}
+
 
 /******************
 evma_setuid_string

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1411,8 +1411,9 @@ void AcceptorDescriptor::Read()
 
 	struct sockaddr_in pin;
 	socklen_t addrlen = sizeof (pin);
+	int accept_count = EventMachine_t::GetSimultaneousAcceptCount();
 
-	for (int i=0; i < 10; i++) {
+	for (int i=0; i < accept_count; i++) {
 		int sd = accept (GetSocket(), (struct sockaddr*)&pin, &addrlen);
 		if (sd == INVALID_SOCKET) {
 			// This breaks the loop when we've accepted everything on the kernel queue,

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -27,6 +27,11 @@ See the file COPYING for complete licensing information.
  */
 static unsigned int MaxOutstandingTimers = 100000;
 
+/* The number of accept() done at once in a single tick when the acceptor
+ * socket becomes readable.
+ */
+static unsigned int SimultaneousAcceptCount = 10;
+
 
 /* Internal helper to convert strings to internet addresses. IPv6-aware.
  * Not reentrant or threadsafe, optimized for speed.
@@ -61,6 +66,17 @@ void EventMachine_t::SetMaxTimerCount (int count)
 	MaxOutstandingTimers = count;
 }
 
+int EventMachine_t::GetSimultaneousAcceptCount()
+{
+	return SimultaneousAcceptCount;
+}
+
+void EventMachine_t::SetSimultaneousAcceptCount (int count)
+{
+	if (count < 1)
+		count = 1;
+	SimultaneousAcceptCount = count;
+}
 
 
 /******************************

--- a/ext/em.h
+++ b/ext/em.h
@@ -69,6 +69,9 @@ class EventMachine_t
 	public:
 		static int GetMaxTimerCount();
 		static void SetMaxTimerCount (int);
+		
+		static int GetSimultaneousAcceptCount();
+		static void SetSimultaneousAcceptCount (int);
 
 	public:
 		EventMachine_t (EMCallback);

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -95,6 +95,8 @@ extern "C" {
 	void evma_set_timer_quantum (int);
 	int evma_get_max_timer_count();
 	void evma_set_max_timer_count (int);
+	int evma_get_simultaneous_accept_count();
+	void evma_set_simultaneous_accept_count (int);
 	void evma_setuid_string (const char *username);
 	void evma_stop_machine();
 	float evma_get_heartbeat_interval();

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -780,6 +780,21 @@ static VALUE t_set_max_timer_count (VALUE self, VALUE ct)
   return Qnil;
 }
 
+/********************
+t_get/set_simultaneous_accept_count
+********************/
+
+static VALUE t_get_simultaneous_accept_count (VALUE self)
+{
+  return INT2FIX (evma_get_simultaneous_accept_count());
+}
+
+static VALUE t_set_simultaneous_accept_count (VALUE self, VALUE ct)
+{
+  evma_set_simultaneous_accept_count (FIX2INT (ct));
+  return Qnil;
+}
+
 /***************
 t_setuid_string
 ***************/
@@ -1250,6 +1265,8 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "set_timer_quantum", (VALUE(*)(...))t_set_timer_quantum, 1);
 	rb_define_module_function (EmModule, "get_max_timer_count", (VALUE(*)(...))t_get_max_timer_count, 0);
 	rb_define_module_function (EmModule, "set_max_timer_count", (VALUE(*)(...))t_set_max_timer_count, 1);
+	rb_define_module_function (EmModule, "get_simultaneous_accept_count", (VALUE(*)(...))t_get_simultaneous_accept_count, 0);
+	rb_define_module_function (EmModule, "set_simultaneous_accept_count", (VALUE(*)(...))t_set_simultaneous_accept_count, 1);
 	rb_define_module_function (EmModule, "setuid_string", (VALUE(*)(...))t_setuid_string, 1);
 	rb_define_module_function (EmModule, "invoke_popen", (VALUE(*)(...))t_invoke_popen, 1);
 	rb_define_module_function (EmModule, "send_file_data", (VALUE(*)(...))t_send_file_data, 2);


### PR DESCRIPTION
This controls the number of calls to `accept(2)` done in one turn in the loop. The default value is `10`, like before, so it won't change the default behaviour of EM.

The purpose of this it to prevent EM from accepting more connections than it can handle. 
My end goal is to set this to `1` in Thin.

Also add EM.get_simultaneous_accept_count to retreive the value.

If necessary, I can port my changes to the Java backend. Let me know.

/cc @raggi