### PR TITLE
EventMachine.fork_reactor keeps the threadpool of the original process.

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -263,6 +263,14 @@ module EventMachine
         self.release_machine
         @reactor_running = false
       end
+      # the threadpool is contained inside the EventMachine class, so it isn't released with the machine.
+      # release everything associated with it so that the child process doesn't have the parents deferred threads in the pool
+      if @threadpool
+        @threadqueue = nil
+        @resultqueue = nil
+        @threadpool = nil
+        @all_threads_spawned = false
+      end
       self.run block
     end
   end


### PR DESCRIPTION
When you fork a new reactor instance, the old eventmachine instance gets destroyed and recreated (in the c) with release_machine. However, because the threadpool is held inside the ruby code, the new machine has the (dead) threads associated with the old instance, which can fill up the threadpool and cause the new reactor to not be able to
execute any defer calls.

To replicate this bug:

    require 'logger'
    require 'eventmachine'
 
    @logger = Logger.new('eventmachine.log')
    EventMachine.run do
      20.times do
        EventMachine.defer do
          sleep(10)
         @logger.debug "Waking up"
        end
      end
      EventMachine.fork_reactor do
        EventMachine.defer do
          @logger.debug "Sleeper not hit"
        end
      end
    end


This pull request takes the code from the main run loop that resets the the threadpool and uses it on the forked reactor to reset the threadpool associated with it.