### PR TITLE
Fix crash on attach/detach in the same tick

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1399,6 +1399,14 @@ int EventMachine_t::DetachFD (EventableDescriptor *ed)
 	// Prevent the descriptor from being modified, in case DetachFD was called from a timer or next_tick
 	ModifiedDescriptors.erase (ed);
 
+	// Prevent the descriptor from being added, in case DetachFD was called in the same tick as AttachFD
+	for (size_t i = 0; i < NewDescriptors.size(); i++) {
+		if (ed == NewDescriptors[i]) {
+			NewDescriptors.erase(NewDescriptors.begin() + i);
+			break;
+		}
+	}
+
 	// Set MySocket = INVALID_SOCKET so ShouldDelete() is true (and the descriptor gets deleted and removed),
 	// and also to prevent anyone from calling close() on the detached fd
 	ed->SetSocketInvalid();

--- a/tests/test_epoll.rb
+++ b/tests/test_epoll.rb
@@ -126,5 +126,20 @@ class TestEpoll < Test::Unit::TestCase
     File.unlink(fn) if File.exist?(fn)
   end
 
+  def test_attach_detach
+    EM.epoll
+    EM.run {
+      EM.add_timer(0.01) { EM.stop }
+
+      r, w = IO.pipe
+
+      # This tests a regression where detach in the same tick as attach crashes EM
+      EM.watch(r) do |connection|
+        connection.detach
+      end
+    }
+
+    assert true
+  end
 end
 


### PR DESCRIPTION
Remove descriptor from `NewDescriptors` when it is detached to fix this issue.
