### PR TITLE
em/pure_ruby: Unable to bind Loopbreaker (RuntimeError) on OS X (Use 127.0.0.1 instead of localhost in em/pure_ruby)

### DIFF
--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -393,7 +393,7 @@ module EventMachine
       100.times {
         @loopbreak_port = rand(10000) + 40000
         begin
-          @loopbreak_reader.bind "localhost", @loopbreak_port
+          @loopbreak_reader.bind "127.0.0.1", @loopbreak_port
           bound = true
           break
         rescue


### PR DESCRIPTION
Running rackup on a thin + synchrony sinatra app:

```
[!]You shold install `padrino-helpers' gem if you want to use kaminari's pagination helpers with Sinatra.
[!]Kaminari::Helpers::SinatraHelper does nothing now...
>> Thin web server (v1.3.1 codename Triple Espresso)
>> Maximum connections set to 1024
>> Listening on 0.0.0.0:9940, CTRL+C to stop
/Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/eventmachine-1.0.0.beta.3/lib/em/pure_ruby.rb:393:in `open_loopbreaker': Unable to bind Loopbreaker (RuntimeError)
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/eventmachine-1.0.0.beta.3/lib/em/pure_ruby.rb:306:in `run'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/eventmachine-1.0.0.beta.3/lib/em/pure_ruby.rb:61:in `run_machine'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/eventmachine-1.0.0.beta.3/lib/eventmachine.rb:199:in `run'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/thin-1.3.1/lib/thin/backends/base.rb:61:in `start'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/thin-1.3.1/lib/thin/server.rb:159:in `start'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.4.1/lib/rack/handler/thin.rb:13:in `run'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.4.1/lib/rack/server.rb:265:in `start'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.4.1/lib/rack/server.rb:137:in `start'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.4.1/bin/rackup:4:in `<top (required)>'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/bin/rackup:19:in `load'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/bin/rackup:19:in `<main>'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `eval'
	from /Users/noice/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `<main>'
```

Removed rescue from lib/em/pure_ruby.rb:392 shows this error:

```
/Users/noice/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/resolv-replace.rb:33:in `bind': Invalid argument - bind(2) (Errno::EINVAL)
	from /Users/noice/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/resolv-replace.rb:33:in `bind'
```

So I changed `.bind("localhost"..)` to `.bind("127.0.0.1"...)` and it works.
Is this the right solution? Or binding to localhost works on other OS and using 127.0.0.1 is considered bad technique?