### PR TITLE
Make ScheduleClose() idempotent

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -259,6 +259,7 @@ evma_num_close_scheduled
 
 extern "C" int evma_num_close_scheduled ()
 {
+	ensure_eventmachine("evma_num_close_scheduled");
 	return EventMachine->NumCloseScheduled;
 }
 

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -217,6 +217,8 @@ EventableDescriptor::ScheduleClose
 
 void EventableDescriptor::ScheduleClose (bool after_writing)
 {
+	if (IsCloseScheduled())
+		return;
 	MyEventMachine->NumCloseScheduled++;
 	// KEEP THIS SYNCHRONIZED WITH ::IsCloseScheduled.
 	if (after_writing)

--- a/tests/test_connection_count.rb
+++ b/tests/test_connection_count.rb
@@ -30,4 +30,24 @@ class TestConnectionCount < Test::Unit::TestCase
     assert_equal(1, $server_conns)
     assert_equal(4, $client_conns + $server_conns)
   end
+
+  module DoubleCloseClient
+    def unbind
+      close_connection
+      $num_close_scheduled_1 = EM.num_close_scheduled
+      EM.next_tick do
+        $num_close_scheduled_2 = EM.num_close_scheduled
+        EM.stop
+      end
+    end
+  end
+
+  def test_num_close_scheduled
+    EM.run {
+      assert_equal(0, EM.num_close_scheduled)
+      EM.connect("127.0.0.1", 9999, DoubleCloseClient) # nothing listening on 9999
+    }
+    assert_equal(1, $num_close_scheduled_1)
+    assert_equal(0, $num_close_scheduled_2)
+  end
 end


### PR DESCRIPTION
I think this fixes issue #441.

8b613d05047ad6954f7d856b1404522214e8f001 changed the `select` timeout to zero in the case where `NumCloseScheduled > 0`. It seems that in certain circumstances (for example, if `close_connection` is called in a connection's `unbind`) `NumCloseScheduled` would get incremented twice, but only decremented once, thus never again reaching zero for the lifetime of the reactor.

The user-observed effect was that one CPU core would be pegged at 100%, because the zero `select` timeout caused us to go around the select loop without any pause.

Changing it so that it is safe to call `ScheduleClose()` multiple times seems like the cleanest solution to the problem.
