### PR TITLE
prevent busy loop in ruby 1.8.7 exception handling

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -957,13 +957,16 @@ module EventMachine
       callback = @next_tick_mutex.synchronize { @next_tick_queue.shift }
       begin
         callback.call
+      rescue
+        exception_raised = true
+        raise
       ensure
         # This is a little nasty. The problem is, if an exception occurs during
         # the callback, then we need to send a signal to the reactor to actually
         # do some work during the next_tick. The only mechanism we have from the
         # ruby side is next_tick itself, although ideally, we'd just drop a byte
         # on the loopback descriptor.
-        EM.next_tick {} if $!
+        EM.next_tick {} if exception_raised
       end
     end
   end


### PR DESCRIPTION
Not sure what the support policy is for 1.8.7, but I ran into a case where the EM thread enters a busy loop and uses ever-increasing memory if EM.run happens to be called from an exception handler. Here is a minimal repro:

https://gist.github.com/manlon/6058884

The behavior or $! seems fixed in ruby 1.9 but it is easy enough to work around here.
