### PR TITLE
Added EM::Connection#close_write

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -538,8 +538,8 @@ ConnectionDescriptor::ScheduleClose
 
 void ConnectionDescriptor::ScheduleClose (bool after_writing)
 {
-	if (bWatchOnly)
-        rb_raise(rb_eRuntimeError, "cannot close 'watch only' connections");
+	//if (bWatchOnly)
+	//	throw std::runtime_error ("cannot close 'watch only' connections");
 
 	EventableDescriptor::ScheduleClose(after_writing);
 }


### PR DESCRIPTION
EM.popen needs to half-close the duplex descriptor so that the subprocess can detect EOF.

Here is typical use case:

``` ruby
EM.run do
  EM.popen "cat", (Module.new do
    define_method :post_init do
      send_data "hello\n"
      EM.next_tick{close_write}
    end
    define_method :receive_data do |data|
      puts data
    end
    define_method(:unbind){EM.stop}
  end)
end
```
