### PR TITLE
Add pause/resume support  for PipeDescriptor in the case use the EPOLL.

### DIFF
--- a/ext/ed.h
+++ b/ext/ed.h
@@ -339,6 +339,9 @@ class PipeDescriptor: public EventableDescriptor
 		PipeDescriptor (int, pid_t, EventMachine_t*);
 		virtual ~PipeDescriptor();
 
+		bool Pause();
+		bool Resume();
+
 		virtual void Read();
 		virtual void Write();
 		virtual void Heartbeat();
@@ -369,6 +372,7 @@ class PipeDescriptor: public EventableDescriptor
 		pid_t SubprocessPid;
 
 	private:
+		void _UpdateEvents();
 		void _DispatchInboundData (const char *buffer, int size);
 };
 #endif // OS_UNIX

--- a/tests/test_processes.rb
+++ b/tests/test_processes.rb
@@ -112,7 +112,7 @@ class TestProcesses < Test::Unit::TestCase
       end
 
       EM.run{
-        EM.popen('cat /dev/random', test_client)
+        EM.popen('cat /dev/urandom', test_client)
       }
 
       assert_equal 1, c_rx


### PR DESCRIPTION
I add pause/resume support  for PipeDescriptor in the case use the EPOLL.
I suspect kqueue would probably work. But I don't have a way to test it.
