### PR TITLE
Immediate pause from receive_data

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -785,6 +785,8 @@ void ConnectionDescriptor::Read()
 			// a security guard against buffer overflows.
 			readbuffer [r] = 0;
 			_DispatchInboundData (readbuffer, r);
+			if (bPaused)
+				break;
 		}
 		else if (r == 0) {
 			break;


### PR DESCRIPTION
Previously, calling pause from inside receive_data would not guarantee that reads were paused until the next reactor tick.
