### PR TITLE
Return the signature ID from EventMachine.attach_server.

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -538,6 +538,7 @@ module EventMachine
     sd = sock.respond_to?(:fileno) ? sock.fileno : sock
     s = attach_sd(sd)
     @acceptors[s] = [klass,args,block,sock]
+    s
   end
 
   # Stop a TCP server socket that was started with {EventMachine.start_server}.

--- a/tests/test_attach.rb
+++ b/tests/test_attach.rb
@@ -68,8 +68,9 @@ class TestAttach < Test::Unit::TestCase
 
   def test_attach_server
     $before = TCPServer.new("127.0.0.1", @port)
+    sig     = nil
     EM.run {
-      EM.attach_server $before, EchoServer
+      sig = EM.attach_server $before, EchoServer
 
       handler = Class.new(EM::Connection) do
         def initialize
@@ -83,6 +84,7 @@ class TestAttach < Test::Unit::TestCase
 
     assert_equal false, $before.closed?
     assert_equal "hello world", $received_data
+    assert sig.is_a?(Integer)
   end
 
   def test_attach_pipe


### PR DESCRIPTION
Based on the discussion in #465, I think it makes more sense to return the signature than the acceptor state.

/cc @tmm1, @brianmario
