### PR TITLE
Add get_file_descriptor which returns the FD number of a signature

### DIFF
--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -566,6 +566,14 @@ static VALUE t_detach_fd (VALUE self, VALUE signature)
 	return INT2NUM(evma_detach_fd (NUM2ULONG (signature)));
 }
 
+/*********************
+t_get_file_descriptor
+*********************/
+static VALUE t_get_file_descriptor (VALUE self, VALUE signature)
+{
+	return INT2NUM(evma_get_file_descriptor (NUM2ULONG (signature)));
+}
+
 /**************
 t_get_sock_opt
 **************/
@@ -1217,6 +1225,7 @@ extern "C" void Init_rubyeventmachine()
 
 	rb_define_module_function (EmModule, "attach_fd", (VALUE (*)(...))t_attach_fd, 2);
 	rb_define_module_function (EmModule, "detach_fd", (VALUE (*)(...))t_detach_fd, 1);
+	rb_define_module_function (EmModule, "get_file_descriptor", (VALUE (*)(...))t_get_file_descriptor, 1);
 	rb_define_module_function (EmModule, "get_sock_opt", (VALUE (*)(...))t_get_sock_opt, 3);
 	rb_define_module_function (EmModule, "set_sock_opt", (VALUE (*)(...))t_set_sock_opt, 4);
 	rb_define_module_function (EmModule, "set_notify_readable", (VALUE (*)(...))t_set_notify_readable, 2);


### PR DESCRIPTION
The name of this method might not be the best, but this pulls in 751132d2203e1748aa38b33d0e4cb812b9de69f0 from https://github.com/eventmachine/eventmachine/pull/165 since it's all we really need to do the fork+exec work ourselves.
