### PR TITLE
Fix for #477

### DIFF
--- a/java/src/com/rubyeventmachine/EmReactor.java
+++ b/java/src/com/rubyeventmachine/EmReactor.java
@@ -169,9 +169,9 @@ public class EmReactor {
 			if (diff <= 0)
 				timeout = -1; // don't wait, just poll once
 			else
-				timeout = diff;
+				timeout = diff > timerQuantum ? timerQuantum : diff;
 		} else {
-			timeout = 0; // wait indefinitely
+			timeout = timerQuantum;
 		}
 
 		try {


### PR DESCRIPTION
Resolves #477, IO waits in Java code checkIO are reduced to at most timerQuantum miliseconds
