### PR TITLE
Create file descriptors with O_CLOEXEC where possible

### DIFF
--- a/ext/ed.h
+++ b/ext/ed.h
@@ -27,7 +27,7 @@ class SslBox_t; // forward reference
 #endif
 
 bool SetSocketNonblocking (SOCKET);
-
+bool SetFdCloexec (int);
 
 /*************************
 class EventableDescriptor
@@ -418,5 +418,3 @@ class InotifyDescriptor: public EventableDescriptor
 };
 
 #endif // __EventableDescriptor__H_
-
-

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -76,6 +76,9 @@ add_define "HAVE_OLD_INOTIFY" if !inotify && have_macro('__NR_inotify_init', 'sy
 add_define 'HAVE_WRITEV' if have_func('writev', 'sys/uio.h')
 add_define 'HAVE_RB_THREAD_FD_SELECT' if have_func('rb_thread_fd_select')
 add_define 'HAVE_RB_FDSET_T' if have_type('rb_fdset_t', 'ruby/intern.h')
+add_define 'HAVE_PIPE2' if have_func('pipe2', 'unistd.h')
+add_define 'HAVE_ACCEPT4' if have_func('accept4', 'sys/socket.h')
+add_define 'HAVE_SOCK_CLOEXEC' if have_const('SOCK_CLOEXEC', 'sys/socket.h')
 
 have_func('rb_wait_for_single_fd')
 have_func('rb_enable_interrupt')


### PR DESCRIPTION
Where possible and supported by the operating system, pass creation-time flag arguments that create close-on-exec file descriptors. On platforms (e.g. OS X) that don't support pipe2(2), accept4(2), or SOCK_CLOEXEC, fall back to creating non-close-on-exec descriptors.

Based on patches by Greg Brockman, Patrick Collison