### PR TITLE
Add some basic tests that the DNS resolver isn't leaking timers

### DIFF
--- a/tests/test_resolver.rb
+++ b/tests/test_resolver.rb
@@ -52,4 +52,30 @@ class TestResolver < Test::Unit::TestCase
       }
     }
   end
+
+  def test_timer_cleanup
+    EM.run {
+      d = EM::DNS::Resolver.resolve "google.com"
+      d.errback { assert false }
+      d.callback { |r|
+        # This isn't a great test, but it's hard to get more canonical
+        # confirmation that the timer is cancelled
+        assert_nil(EM::DNS::Resolver.socket.instance_variable_get(:@timer))
+
+        EM.stop
+      }
+    }
+  end
+
+  def test_failure_timer_cleanup
+    EM.run {
+      d = EM::DNS::Resolver.resolve "asdfasdf"
+      d.callback { assert false }
+      d.errback {
+        assert_nil(EM::DNS::Resolver.socket.instance_variable_get(:@timer))
+
+        EM.stop
+      }
+    }
+  end
 end


### PR DESCRIPTION
It's a pretty crude test - among other things, it relies on `stop_timer` only setting `@timer` to nil once it's cancelled the timer.

But it's hard to do better - since `@timer` does in fact get nil'd out, we can't poke to see if the timer was cancelled, and since cancellation of periodic timers doesn't deregister the callback, we can't look at `EM.instance_variable_get(:@timers)`.