### PR TITLE
Fix class documentation formatting for TickLoop

### DIFF
--- a/lib/em/tick_loop.rb
+++ b/lib/em/tick_loop.rb
@@ -13,6 +13,7 @@ module EventMachine
   #   # When the array is empty, we return :stop from the callback, and the
   #   # loop will terminate.
   #   # When the loop terminates, the on_stop callbacks will be called.
+  #
   #   EM.run do
   #     array = (1..100).to_a
   #   


### PR DESCRIPTION
The additional newline is needed for the code to be formatted correctly in the RubyDoc documentation: http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/TickLoop
