### PR TITLE
Use the rb_fd_* API to get autosized fd_sets

### DIFF
--- a/ext/em.h
+++ b/ext/em.h
@@ -66,6 +66,9 @@ See the file COPYING for complete licensing information.
 
 #ifndef rb_fd_max
 #define fd_check(n) (((n) < FD_SETSIZE) ? 1 : 0*fprintf(stderr, "fd %d too large for select\n", (n)))
+// These definitions are cribbed from include/ruby/intern.h in Ruby 1.9.3,
+// with this change: any macros that read or write the nth element of an
+// fdset first call fd_check to make sure n is in bounds.
 typedef fd_set rb_fdset_t;
 #define rb_fd_zero(f) FD_ZERO(f)
 #define rb_fd_set(n, f) do { if (fd_check(n)) FD_SET((n), (f)); } while(0)

--- a/ext/em.h
+++ b/ext/em.h
@@ -64,6 +64,27 @@ See the file COPYING for complete licensing information.
   #define EmSelect rb_fd_select
 #endif
 
+#ifndef rb_fd_max
+#define fd_check(n) (((n) < FD_SETSIZE) ? 1 : 0*fprintf(stderr, "fd %d too large for select\n", (n)))
+typedef fd_set rb_fdset_t;
+#define rb_fd_zero(f) FD_ZERO(f)
+#define rb_fd_set(n, f) do { if (fd_check(n)) FD_SET((n), (f)); } while(0)
+#define rb_fd_clr(n, f) do { if (fd_check(n)) FD_CLR((n), (f)); } while(0)
+#define rb_fd_isset(n, f) (fd_check(n) ? FD_ISSET((n), (f)) : 0)
+#define rb_fd_copy(d, s, n) (*(d) = *(s))
+#define rb_fd_dup(d, s) (*(d) = *(s))
+#define rb_fd_resize(n, f)  ((void)(f))
+#define rb_fd_ptr(f)  (f)
+#define rb_fd_init(f) FD_ZERO(f)
+#define rb_fd_init_copy(d, s) (*(d) = *(s))
+#define rb_fd_term(f) ((void)(f))
+#define rb_fd_max(f)  FD_SETSIZE
+#define rb_fd_select(n, rfds, wfds, efds, timeout)  \
+  select(fd_check((n)-1) ? (n) : FD_SETSIZE, (rfds), (wfds), (efds), (timeout))
+#define rb_thread_fd_select(n, rfds, wfds, efds, timeout)  \
+  rb_thread_select(fd_check((n)-1) ? (n) : FD_SETSIZE, (rfds), (wfds), (efds), (timeout))
+#endif
+
 class EventableDescriptor;
 class InotifyDescriptor;
 

--- a/ext/em.h
+++ b/ext/em.h
@@ -22,12 +22,7 @@ See the file COPYING for complete licensing information.
 
 #ifdef BUILD_FOR_RUBY
   #include <ruby.h>
-
-  #ifdef HAVE_RB_THREAD_FD_SELECT
-    #define EmSelect rb_thread_fd_select
-  #else
-    #define EmSelect rb_thread_select
-  #endif
+  #define EmSelect rb_thread_fd_select
 
   #ifdef HAVE_RB_THREAD_CALL_WITHOUT_GVL
    #include <ruby/thread.h>
@@ -66,7 +61,7 @@ See the file COPYING for complete licensing information.
     #define RSTRING_LENINT(str) RSTRING_LEN(str)
   #endif
 #else
-  #define EmSelect select
+  #define EmSelect rb_fd_select
 #endif
 
 class EventableDescriptor;
@@ -243,9 +238,9 @@ struct SelectData_t
 	int _Select();
 
 	int maxsocket;
-	fd_set fdreads;
-	fd_set fdwrites;
-	fd_set fderrors;
+	rb_fdset_t fdreads;
+	rb_fdset_t fdwrites;
+	rb_fdset_t fderrors;
 	timeval tv;
 	int nSockets;
 };

--- a/tests/test_many_fds.rb
+++ b/tests/test_many_fds.rb
@@ -1,0 +1,22 @@
+require 'em_test_helper'
+require 'socket'
+
+class TestManyFDs < Test::Unit::TestCase
+  def setup
+    @port = next_port
+  end
+
+  def test_connection_class_cache
+    mod = Module.new
+    a = nil
+    Process.setrlimit(Process::RLIMIT_NOFILE,4096);
+    EM.run {
+      EM.start_server '127.0.0.1', @port, mod
+      1100.times do
+        a = EM.connect '127.0.0.1', @port, mod
+        assert_kind_of EM::Connection, a
+      end
+      EM.stop
+    }
+  end
+end


### PR DESCRIPTION
Fixes #501

On Ruby 1.9.1 and up, we use `rb_fd_select` and friends to get automatically resized `fd_set`s.  This should transparently provide correct behavior for `select` even when fds exceed `FD_SETSIZE` (1024).

On Ruby 1.8.7 and 1.9.0, we use stubs that warn to stdout whenever anyone tries to `FD_SET`, `FD_CLR`, `FD_ISSET`, or `select` an fd >= `FD_SETSIZE`.  This behavior isn't correct, in that it's noisy and doesn't do anything useful with the high FDs.  But it's better than the current behavior, which is undefined and usually crashes with an unrelated assert or heap corruption after the first high FD.

There's another branch [here](https://github.com/piki/eventmachine/blob/backport-rb-fd/ext/rbselect.impl) that backports the rb_fd_* API.  I've only tested that branch on Debian squeeze (6.0), which has Ruby 1.8.7.  It's unlikely to work on WIN32 without further effort.  I can merge it into this PR if someone wants to tidy it up for Ruby <= 1.9.0 on WIN32.
