### PR TITLE
Fix build error on Ruby 2.2.0

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -832,15 +832,15 @@ SelectData_t::_Select
 
 int SelectData_t::_Select()
 {
-#if defined(HAVE_TBR)
-  rb_thread_blocking_region (_SelectDataSelect, (void*)this, RUBY_UBF_IO, 0);
-  return nSockets;
-#elif defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
-  rb_thread_call_without_gvl ((void *(*)(void *))_SelectDataSelect, (void*)this, RUBY_UBF_IO, 0);
-  return nSockets;
-#else
+	#if defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
+	rb_thread_call_without_gvl ((void *(*)(void *))_SelectDataSelect, (void*)this, RUBY_UBF_IO, 0);
+	return nSockets;
+	#elif defined(HAVE_TBR)
+	rb_thread_blocking_region (_SelectDataSelect, (void*)this, RUBY_UBF_IO, 0);
+	return nSockets;
+	#else
 	return EmSelect (maxsocket+1, &fdreads, &fdwrites, &fderrors, &tv);
-#endif
+	#endif
 }
 #endif
 

--- a/ext/em.h
+++ b/ext/em.h
@@ -23,15 +23,15 @@ See the file COPYING for complete licensing information.
 #ifdef BUILD_FOR_RUBY
   #include <ruby.h>
 
-#if defined(HAVE_RB_THREAD_SELECT)
-  #define EmSelect rb_thread_select
-#elif defined(HAVE_RB_THREAD_FD_SELECT)
-  #define EmSelect rb_thread_fd_select
-#endif
+  #ifdef HAVE_RB_THREAD_FD_SELECT
+    #define EmSelect rb_thread_fd_select
+  #else
+    #define EmSelect rb_thread_select
+  #endif
 
-#if defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
-  #include <ruby/thread.h>
-#endif
+  #ifdef HAVE_RB_THREAD_CALL_WITHOUT_GVL
+   #include <ruby/thread.h>
+  #endif
 
   #ifdef HAVE_RB_WAIT_FOR_SINGLE_FD
     #include <ruby/io.h>

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -71,7 +71,6 @@ add_define "HAVE_RB_THREAD_CALL_WITHOUT_GVL" if have_func('rb_thread_call_withou
 add_define "HAVE_INOTIFY" if inotify = have_func('inotify_init', 'sys/inotify.h')
 add_define "HAVE_OLD_INOTIFY" if !inotify && have_macro('__NR_inotify_init', 'sys/syscall.h')
 add_define 'HAVE_WRITEV' if have_func('writev', 'sys/uio.h')
-add_define 'HAVE_RB_THREAD_SELECT' if have_func('rb_thread_select')
 add_define 'HAVE_RB_THREAD_FD_SELECT' if have_func('rb_thread_fd_select')
 
 have_func('rb_wait_for_single_fd')


### PR DESCRIPTION
rb_thread_blocking_region and rb_thread_select is removed from Ruby 2.2.0. I fixed it used by rb_thread_call_without_gvl and rb_thread_fd_select.
