### PR TITLE
Fix the tick_loop example documentation layout.

### DIFF
--- a/lib/em/tick_loop.rb
+++ b/lib/em/tick_loop.rb
@@ -7,25 +7,25 @@ module EventMachine
   # A TickLoop is useful when one needs to distribute amounts of work
   # throughout ticks in order to maintain response times. It is also useful for
   # simple repeated checks and metrics.
-  # 
-  #   # Here we run through an array one item per tick until it is empty, 
-  #   # printing each element.
-  #   # When the array is empty, we return :stop from the callback, and the
-  #   # loop will terminate.
-  #   # When the loop terminates, the on_stop callbacks will be called.
-  #   EM.run do
-  #     array = (1..100).to_a
-  #   
-  #     tickloop = EM.tick_loop do
-  #       if array.empty?
-  #         :stop
-  #       else
-  #         puts array.shift
-  #       end
-  #     end
-  #   
-  #     tickloop.on_stop { EM.stop }
-  #   end
+  # @example
+  #    # Here we run through an array one item per tick until it is empty, 
+  #    # printing each element.
+  #    # When the array is empty, we return :stop from the callback, and the
+  #    # loop will terminate.
+  #    # When the loop terminates, the on_stop callbacks will be called.  
+  #    EM.run do
+  #      array = (1..100).to_a
+  #      
+  #      tickloop = EM.tick_loop do
+  #        if array.empty?
+  #          :stop
+  #        else
+  #          puts array.shift
+  #        end
+  #      end
+  #      
+  #      tickloop.on_stop { EM.stop }
+  #    end
   #
   class TickLoop
 


### PR DESCRIPTION
# Before

(as can be seen [here](http://eventmachine.rubyforge.org/EventMachine/TickLoop.html))

![Before](https://api.monosnap.com/image/download?id=1MCTshDaqk3xG93sh3SuFGtLGtZVNW)
# After

![After](https://api.monosnap.com/image/download?id=LFDwaWzWX0tSk9d9MEYHCpP35ny2eN)
