### PR TITLE
Add Ruby 2.0.0 and Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 script: rake compile test
 language: ruby
 rvm:
-  - 1.8.7
+  - 2.1.2
+  - 2.0.0
   - 1.9.3
-  - rbx-18mode
+  - 1.8.7
   - rbx-19mode
+  - rbx-18mode
   - jruby
 matrix:
   allow_failures:
-    - rvm: rbx-18mode
     - rvm: rbx-19mode
+    - rvm: rbx-18mode

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ EventMachine has been around since the early 2000s and is a mature and battle te
 
 ## What platforms are supported by EventMachine? ##
 
-EventMachine supports Ruby 1.8.7, 1.9.2, REE, JRuby and **works well on Windows** as well
+EventMachine supports Ruby 1.8.7, 1.9.2, 2.0.0, 2.1.2, REE, JRuby and **works well on Windows** as well
 as many operating systems from the Unix family (Linux, Mac OS X, BSD flavors).
 
 


### PR DESCRIPTION
Would be great to know that Ruby 2.1.2 is supported.