### PR TITLE
Avoid calling Write() if SelectForWrite() value has changed

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -973,8 +973,12 @@ void EventMachine_t::_RunSelectOnce()
 					continue;
 				assert (sd != INVALID_SOCKET);
 
-				if (rb_fd_isset (sd, &(SelectData.fdwrites)))
-					ed->Write();
+				if (rb_fd_isset (sd, &(SelectData.fdwrites))) {
+					// Double-check SelectForWrite() still returns true. If not, one of the callbacks must have
+					// modified some value since we checked SelectForWrite() earlier in this method.
+					if (ed->SelectForWrite())
+						ed->Write();
+				}
 				if (rb_fd_isset (sd, &(SelectData.fdreads)))
 					ed->Read();
 				if (rb_fd_isset (sd, &(SelectData.fderrors)))

--- a/tests/test_connection_write.rb
+++ b/tests/test_connection_write.rb
@@ -1,0 +1,35 @@
+require 'em_test_helper'
+
+class TestConnectionWrite < Test::Unit::TestCase
+
+  # This test takes advantage of the fact that EM::_RunSelectOnce iterates over the connections twice:
+  #   - once to determine which ones to call Write() on
+  #   - and once to call Write() on each of them.
+  #
+  # But state may change in the meantime before Write() is finally called.
+  # And that is what we try to exploit to get Write() to be called when bWatchOnly is true, and bNotifyWritable is false,
+  # to cause an assertion failure.
+
+  module SimpleClient
+    def notify_writable
+      $conn2.notify_writable = false  # Being naughty in callback
+      # If this doesn't crash anything, the test passed!
+    end
+  end
+
+  def test_with_naughty_callback
+    EM.run do
+      r1, w1 = IO.pipe
+      r2, w2 = IO.pipe
+
+      # Adding EM.watches
+      $conn1 = EM.watch(r1, SimpleClient)
+      $conn2 = EM.watch(r2, SimpleClient)
+
+      $conn1.notify_writable = true
+      $conn2.notify_writable = true
+
+      EM.stop
+    end
+  end
+end


### PR DESCRIPTION
This fixes bug #524.

Added a new unit test which fails in current version of EM, but passes with the included fix to em.cpp.