### PR TITLE
Use clock_gettime and mach_absolute_time to make GetRealTime monotonic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ matrix:
   allow_failures:
     - rvm: rbx
     - rvm: jruby
+  include:
+    - rvm: 2.0.0
+      os: osx

--- a/ext/em.h
+++ b/ext/em.h
@@ -232,6 +232,10 @@ class EventMachine_t
 		unsigned LastTickCount;
 		#endif
 
+		#ifdef OS_DARWIN
+		mach_timebase_info_data_t mach_timebase;
+		#endif
+
 	private:
 		bool bTerminateSignalReceived;
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -139,6 +139,8 @@ when /openbsd/
   CONFIG['LDSHAREDXX'] = "$(CXX) -shared -lstdc++ -fPIC"
 
 when /darwin/
+  add_define 'OS_DARWIN'
+
   # on Unix we need a g++ link, not gcc.
   # Ff line contributed by Daniel Harple.
   CONFIG['LDSHARED'] = "$(CXX) " + CONFIG['LDSHARED'].split[1..-1].join(' ')
@@ -166,6 +168,14 @@ else
   CONFIG['LDSHARED'] = "$(CXX) -shared"
 end
 
+# Platform-specific time functions
+if have_func('clock_gettime')
+  # clock_gettime is POSIX, but the monotonic clocks are not
+  have_const('CLOCK_MONOTONIC_RAW', 'time.h') # Linux
+  have_const('CLOCK_MONOTONIC', 'time.h') # Linux, Solaris, BSDs
+else
+  have_func('gethrtime') # Older Solaris and HP-UX
+end
 
 # solaris c++ compiler doesn't have make_pair()
 TRY_LINK.sub!('$(CC)', '$(CXX)')

--- a/ext/project.h
+++ b/ext/project.h
@@ -78,6 +78,11 @@ typedef int SOCKET;
 #endif
 #endif /* _AIX */
 
+#ifdef OS_DARWIN
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif /* OS_DARWIN */
+
 #endif /* OS_UNIX */
 
 #ifdef OS_WIN32
@@ -85,7 +90,9 @@ typedef int SOCKET;
 // 18Jun12: fd_setsize must be changed in the ruby binary (not in this extension). redefining it also causes segvs, see eventmachine/eventmachine#333
 //#define FD_SETSIZE 1024
 
+// WIN32_LEAN_AND_MEAN excludes APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets.
 #define WIN32_LEAN_AND_MEAN
+
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
Based on clock_gettime from #496 with support for Mac OS X based on https://developer.apple.com/library/mac/qa/qa1398/_index.html