### PR TITLE
Set file handle to INVALID_HANDLE_VALUE after closing the file.

### DIFF
--- a/ext/fastfilereader/mapper.cpp
+++ b/ext/fastfilereader/mapper.cpp
@@ -195,7 +195,7 @@ void Mapper_t::Close()
 	}
 	if (hFile != INVALID_HANDLE_VALUE) {
 		CloseHandle (hFile);
-		hMapping = INVALID_HANDLE_VALUE;
+		hFile = INVALID_HANDLE_VALUE;
 	}
 }
 


### PR DESCRIPTION
There seems to be a typo when closing the hFile in mapper.cpp.  Instead of setting the hFile, the mapping handle was being set again.