### PR TITLE
Abstract out an EmReactorInterface...

### DIFF
--- a/java/src/com/rubyeventmachine/EmReactorInterface.java
+++ b/java/src/com/rubyeventmachine/EmReactorInterface.java
@@ -1,0 +1,70 @@
+package com.rubyeventmachine;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public interface EmReactorInterface
+{
+	void eventCallback (long sig, int eventType, ByteBuffer data, long data2);
+
+	void eventCallback (long sig, int eventType, ByteBuffer data);
+
+	void run();
+
+	void stop();
+
+	long installOneshotTimer (long milliseconds);
+
+	long startTcpServer (SocketAddress sa) throws EmReactorException;
+
+	long startTcpServer (String address, int port) throws EmReactorException;
+
+	void stopTcpServer (long signature) throws IOException;
+
+	long openUdpSocket (InetSocketAddress address) throws IOException;
+
+	long openUdpSocket (String address, int port) throws IOException;
+
+	void sendData (long sig, ByteBuffer bb) throws IOException;
+
+	void sendData (long sig, byte[] data) throws IOException;
+
+	void setCommInactivityTimeout (long sig, long mills);
+
+	void sendDatagram (long sig, byte[] data, int length, String recipAddress, int recipPort);
+
+	void sendDatagram (long sig, ByteBuffer bb, String recipAddress, int recipPort);
+
+	long connectTcpServer (String address, int port);
+
+	long connectTcpServer (String bindAddr, int bindPort, String address, int port);
+
+	void closeConnection (long sig, boolean afterWriting);
+
+	void signalLoopbreak();
+
+	void startTls (long sig) throws NoSuchAlgorithmException, KeyManagementException;
+
+	void setTimerQuantum (int mills);
+
+	Object[] getPeerName (long sig);
+
+	long attachChannel (SocketChannel sc, boolean watch_mode);
+
+	SocketChannel detachChannel (long sig);
+
+	void setNotifyReadable (long sig, boolean mode);
+
+	void setNotifyWritable (long sig, boolean mode);
+
+	boolean isNotifyReadable (long sig);
+
+	boolean isNotifyWritable (long sig);
+
+	int getConnectionCount();
+}

--- a/java/src/com/rubyeventmachine/NullEmReactor.java
+++ b/java/src/com/rubyeventmachine/NullEmReactor.java
@@ -1,0 +1,157 @@
+package com.rubyeventmachine;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public class NullEmReactor implements EmReactorInterface
+{
+	public void eventCallback(long sig, int eventType, ByteBuffer data, long data2)
+	{
+
+	}
+
+	public void eventCallback(long sig, int eventType, ByteBuffer data)
+	{
+
+	}
+
+	public void run()
+	{
+
+	}
+
+	public void stop()
+	{
+
+	}
+
+	public long installOneshotTimer(long milliseconds)
+	{
+		return 0;
+	}
+
+	public long startTcpServer(SocketAddress sa) throws EmReactorException
+	{
+		return 0;
+	}
+
+	public long startTcpServer(String address, int port) throws EmReactorException
+	{
+		return 0;
+	}
+
+	public void stopTcpServer(long signature) throws IOException
+	{
+
+	}
+
+	public long openUdpSocket(InetSocketAddress address) throws IOException
+	{
+		return 0;
+	}
+
+	public long openUdpSocket(String address, int port) throws IOException
+	{
+		return 0;
+	}
+
+	public void sendData(long sig, ByteBuffer bb) throws IOException
+	{
+
+	}
+
+	public void sendData(long sig, byte[] data) throws IOException
+	{
+
+	}
+
+	public void setCommInactivityTimeout(long sig, long mills)
+	{
+
+	}
+
+	public void sendDatagram(long sig, byte[] data, int length, String recipAddress, int recipPort)
+	{
+
+	}
+
+	public void sendDatagram(long sig, ByteBuffer bb, String recipAddress, int recipPort)
+	{
+
+	}
+
+	public long connectTcpServer(String address, int port)
+	{
+		return 0;
+	}
+
+	public long connectTcpServer(String bindAddr, int bindPort, String address, int port)
+	{
+		return 0;
+	}
+
+	public void closeConnection(long sig, boolean afterWriting)
+	{
+
+	}
+
+	public void signalLoopbreak()
+	{
+
+	}
+
+	public void startTls(long sig) throws NoSuchAlgorithmException, KeyManagementException
+	{
+
+	}
+
+	public void setTimerQuantum(int mills)
+	{
+
+	}
+
+	public Object[] getPeerName(long sig)
+	{
+		return new Object[0];
+	}
+
+	public long attachChannel(SocketChannel sc, boolean watch_mode)
+	{
+		return 0;
+	}
+
+	public SocketChannel detachChannel(long sig)
+	{
+		return null;
+	}
+
+	public void setNotifyReadable(long sig, boolean mode)
+	{
+
+	}
+
+	public void setNotifyWritable(long sig, boolean mode)
+	{
+
+	}
+
+	public boolean isNotifyReadable(long sig)
+	{
+		return false;
+	}
+
+	public boolean isNotifyWritable(long sig)
+	{
+		return false;
+	}
+
+	public int getConnectionCount()
+	{
+		return 0;
+	}
+}

--- a/java/src/com/rubyeventmachine/NullEventableChannel.java
+++ b/java/src/com/rubyeventmachine/NullEventableChannel.java
@@ -1,0 +1,81 @@
+package com.rubyeventmachine;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+
+public class NullEventableChannel implements EventableChannel
+{
+	public void scheduleOutboundData(ByteBuffer bb)
+	{
+	}
+
+	public void scheduleOutboundDatagram(ByteBuffer bb, String recipAddress, int recipPort)
+	{
+	}
+
+	public boolean scheduleClose(boolean afterWriting)
+	{
+		return false;
+	}
+
+	public void startTls()
+	{
+	}
+
+	public long getBinding()
+	{
+		return 0;
+	}
+
+	public void readInboundData(ByteBuffer dst) throws IOException
+	{
+	}
+
+	public void register() throws ClosedChannelException
+	{
+	}
+
+	public void close()
+	{
+	}
+
+	public boolean writeOutboundData() throws IOException
+	{
+		return false;
+	}
+
+	public void setCommInactivityTimeout(long seconds)
+	{
+	}
+
+	public Object[] getPeerName()
+	{
+		return new Object[0];
+	}
+
+	public Object[] getSockName()
+	{
+		return new Object[0];
+	}
+
+	public boolean isWatchOnly()
+	{
+		return false;
+	}
+
+	public boolean isNotifyReadable()
+	{
+		return false;
+	}
+
+	public boolean isNotifyWritable()
+	{
+		return false;
+	}
+
+	public long getOutboundDataSize ()
+	{
+		return 0;
+	}
+}

--- a/lib/jeventmachine.rb
+++ b/lib/jeventmachine.rb
@@ -80,6 +80,9 @@ module EventMachine
   # @private
   SslVerify = 109
 
+  NULL_EM_REACTOR = com.rubyeventmachine.NullEmReactor.new
+  @em ||= NULL_EM_REACTOR
+
   # Exceptions that are defined in rubymain.cpp
   class ConnectionError < RuntimeError; end
   class ConnectionNotBound < RuntimeError; end
@@ -104,7 +107,7 @@ module EventMachine
     @em = JEM.new
   end
   def self.release_machine
-    @em = nil
+    @em = NULL_EM_REACTOR
   end
   def self.add_oneshot_timer interval
     @em.installOneshotTimer interval
@@ -302,4 +305,3 @@ module EventMachine
     end
   end
 end
-

--- a/tests/jruby/test_jeventmachine.rb
+++ b/tests/jruby/test_jeventmachine.rb
@@ -1,0 +1,38 @@
+if !(RUBY_PLATFORM =~ /java/)
+  puts "Ignorming tests in #{__FILE__}.  They must be run in JRuby "
+else
+  require 'test/unit'
+  require 'jeventmachine'
+
+  class TestJEventmachine < Test::Unit::TestCase
+
+    def setup
+      EventMachine.instance_variable_set("@em", nil)
+      load 'jeventmachine.rb'
+    end
+
+    def test_can_make_calls_without_errors_before_initialization
+      assert_equal nil, EventMachine.signal_loopbreak
+      assert_equal nil, EventMachine.stop_tcp_server(123)
+      assert_equal nil, EventMachine.send_data(123, "rewr", 4)
+      assert_equal nil, EventMachine.close_connection(332, nil)
+    end
+
+    def test_create
+      EventMachine::initialize_event_machine
+      em = EventMachine::instance_variable_get("@em")
+      assert_equal true, em.is_a?(Java::com.rubyeventmachine.EmReactor)
+    end
+
+    def test_can_make_calls_without_errors_after_release
+      EventMachine.initialize_event_machine
+      EventMachine.release_machine
+
+      assert_equal nil, EventMachine.signal_loopbreak
+      assert_equal nil, EventMachine.stop_tcp_server(123)
+      assert_equal nil, EventMachine.send_data(123, "rewr", 4)
+      assert_equal nil, EventMachine.close_connection(332, nil)
+    end
+
+  end
+end


### PR DESCRIPTION
Create a NullEmReactor and NullEventableChannel to use when the reactor should not be running.

This is a rebase of PR #124.

I have no idea if this is still needed.
