### PR TITLE
Workaround mkmf devel check bug

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -40,7 +40,7 @@ def manual_ssl_config
 end
 
 # Eager check devs tools
-have_devel?
+have_devel? if respond_to?(:have_devel?)
 
 if ENV['CROSS_COMPILING']
   openssl_version = ENV.fetch("OPENSSL_VERSION", "1.0.1i")

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -39,6 +39,9 @@ def manual_ssl_config
   check_libs(libs) and check_heads(heads)
 end
 
+# Eager check devs tools
+have_devel?
+
 if ENV['CROSS_COMPILING']
   openssl_version = ENV.fetch("OPENSSL_VERSION", "1.0.1i")
   openssl_dir = File.expand_path("~/.rake-compiler/builds/openssl-#{openssl_version}/")

--- a/ext/fastfilereader/extconf.rb
+++ b/ext/fastfilereader/extconf.rb
@@ -12,6 +12,9 @@ def add_define(name)
   $defs.push("-D#{name}")
 end
 
+# Eager check devs tools
+have_devel? if respond_to?(:have_devel?)
+
 add_define 'BUILD_FOR_RUBY'
 
 # Minor platform details between *nix and Windows:


### PR DESCRIPTION
@tmm1 think I found the mkmf bug.

Seems like it depends the order of `try_link` checks. `have_devel?` is check and cached on the first `try_do` call.

https://github.com/ruby/ruby/blob/4b8df18e0d6ef54f93219eb34b7151a79810bafc/lib/mkmf.rb#L455-L460

However, `try_do` maybe called within the scope of `try_ldflags` which changes `$LDFLAGS` for the duration of the scope.

https://github.com/ruby/ruby/blob/4b8df18e0d6ef54f93219eb34b7151a79810bafc/lib/mkmf.rb#L640-L644

If this was the first call to `try_do`, `have_devel?` will incorrectly test with incorrect `$LDFLAGS` and crash immediately.

My work around was to eager check `have_devel?` Not sure how to fix upstream.

Closes #505.