### PR TITLE
Update alternatives section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,4 @@ Copyright: (C) 2006-07 by Francis Cianfrocca. All Rights Reserved.
 
 ## Alternatives ##
 
-If you are unhappy with EventMachine and want to use Ruby, check out [Cool.io](http://coolio.github.com/).
-One caveat: by May 2011, it did not support JRuby and Windows.
+If you are unhappy with EventMachine and want to use Ruby, check out [Celluloid](https://celluloid.io/).


### PR DESCRIPTION
Cool.io is retired and http://coolio.github.io/ points visitors towards Celluloid.