### PR TITLE
Honour requests to close NOW

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -217,8 +217,14 @@ EventableDescriptor::ScheduleClose
 
 void EventableDescriptor::ScheduleClose (bool after_writing)
 {
-	if (IsCloseScheduled())
+	if (IsCloseScheduled()) {
+		if (!after_writing) {
+			// If closing has become more urgent, then upgrade the scheduled
+			// after_writing close to one NOW.
+			bCloseNow = true;
+		}
 		return;
+	}
 	MyEventMachine->NumCloseScheduled++;
 	// KEEP THIS SYNCHRONIZED WITH ::IsCloseScheduled.
 	if (after_writing)


### PR DESCRIPTION
...even if we have previously asked to close later. Many places in the
codebase use ScheduleClose(false) when they have found out that the
socket is no longer operational, but they are being ignored if
ScheduleClose(true) has been used in the past. As the socket is often
not working at this point, we will never get through the send queue and
actually do the close.