### PR TITLE
Signal loopbreaker during halt

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -208,6 +208,12 @@ void EventMachine_t::ScheduleHalt()
    * The answer is to call evma_stop_machine, which calls here, from a SIGINT handler.
    */
 	bTerminateSignalReceived = true;
+
+	/* Signal the loopbreaker so we break out of long-running select/epoll/kqueue and
+	 * notice the halt boolean is set. Signalling the loopbreaker also uses a single
+	 * signal-safe syscall.
+	 */
+	SignalLoopBreaker();
 }
 
 


### PR DESCRIPTION
fixes #522 

confirmed `kill -TERM` works against a kqueue reactor loop after this patch using the repro in https://github.com/eventmachine/eventmachine/issues/522#issue-37535399

```
tmm1@tmm1-air ~/code/eventmachine (loopbreak-at-halt*) $ ruby -Ilib -r eventmachine test.rb
30227
timer
SIGTERM: 1423556870.274626
shutting down: 1423556870.274733
```

/cc @piki