### PR TITLE
Open datagram sockets with CLOEXEC.

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1679,6 +1679,16 @@ const unsigned long EventMachine_t::OpenDatagramSocket (const char *address, int
 			goto fail;
 	}
 
+	// Set CLOEXEC. Only makes sense on Unix.
+	{
+		#ifdef OS_UNIX
+		int cloexec = fcntl (sd, F_GETFD, 0);
+		assert (cloexec >= 0);
+		cloexec |= FD_CLOEXEC;
+		fcntl (sd, F_SETFD, cloexec);
+		#endif
+	}
+
 	if (bind (sd, (struct sockaddr*)&sin, sizeof(sin)) != 0)
 		goto fail;
 


### PR DESCRIPTION
So as not to share them with children, and in particular not fail
to reopen on restart if a child is still around.

This is meant to fix a sensu-client issue (https://github.com/sensu/sensu/issues/862) where the process fails to come back up due to a child that keeps the socket.