### PR TITLE
SmtpClient: Properly escape leading periods in DATA

### DIFF
--- a/lib/em/protocols/smtpclient.rb
+++ b/lib/em/protocols/smtpclient.rb
@@ -48,20 +48,20 @@ module EventMachine
     #     puts 'Email failed!'
     #   }
     #
-    # Sending generated emails (using mailfactory)
+    # Sending generated emails (using Mail)
     #
-    #   mail = MailFactory.new
-    #   mail.to = 'someone@site.co'
-    #   mail.from = 'me@site.com'
-    #   mail.subject = 'hi!'
-    #   mail.text = 'hello world'
-    #   mail.html = '<h1>hello world</h1>'
+    #   mail = Mail.new do
+    #     from    'alice@example.com'
+    #     to      'bob@example.com'
+    #     subject 'This is a test email'
+    #     body    'Hello, world!'
+    #   end
     #
     #   email = EM::P::SmtpClient.send(
-    #     :domain=>'site.com',
-    #     :from=>mail.from,
+    #     :domain=>'example.com',
+    #     :from=>mail.from.first,
     #     :to=>mail.to,
-    #     :content=>"#{mail.to_s}\r\n.\r\n"
+    #     :message=>mail.to_s
     #   )
     #
     class SmtpClient < Connection
@@ -108,25 +108,29 @@ module EventMachine
       #   of each requested recipient is available after the call completes. TODO, we should define
       #   an overridable stub that will be called on rejection of a recipient or a sender, giving
       #   user code the chance to try again or abort the connection.
-      # :header => Required hash of values to be transmitted in the header of the message.
-      #   The hash keys are the names of the headers (do NOT append a trailing colon), and the values are strings
-      #   containing the header values. TODO, support Arrays of header values, which would cause us to
-      #   send that specific header line more than once.
+      #
+      # One of either :message, :content, or :header and :body is required:
+      #
+      # :message => String
+      #   A valid RFC2822 Internet Message.
+      # :content => String
+      #   Raw data which MUST be in correct SMTP body format, with escaped leading dots and a trailing
+      #   dot line.
+      # :header => String or Hash of values to be transmitted in the header of the message.
+      #   The hash keys are the names of the headers (do NOT append a trailing colon), and the values
+      #   are strings containing the header values. TODO, support Arrays of header values, which would
+      #   cause us to send that specific header line more than once.
       #
       #   @example
       #     :header => {"Subject" => "Bogus", "CC" => "myboss@example.com"}
       #
-      # :body => Optional string, defaults blank.
+      # :body => Optional String or Array of Strings, defaults blank.
       #   This will be passed as the body of the email message.
       #   TODO, this needs to be significantly beefed up. As currently written, this requires the caller
       #   to properly format the input into CRLF-delimited lines of 7-bit characters in the standard
       #   SMTP transmission format. We need to be able to automatically convert binary data, and add
-      #   correct line-breaks to text data. I think the :body parameter should remain as it is, and we
-      #   should add a :content parameter that contains autoconversions and/or conversion parameters.
-      #   Then we can check if either :body or :content is present and do the right thing.
-      # :content => Optional array or string
-      #   Alternative to providing header and body, an array or string of raw data which MUST be in
-      #   correct SMTP body format, including a trailing dot line
+      #   correct line-breaks to text data.
+      #
       # :verbose => Optional.
       #   If true, will cause a lot of information (including the server-side of the
       #   conversation) to be dumped to $>.
@@ -316,6 +320,10 @@ module EventMachine
         invoke_rcpt_to
       end
 
+      def escape_leading_dots(s)
+        s.gsub(/^\.([^.]|$)/) { "..#{$1}" }
+      end
+
       def invoke_data
         send_data "DATA\r\n"
         @responder = :receive_data_response
@@ -323,25 +331,34 @@ module EventMachine
       def receive_data_response
         return invoke_error unless @range == 3
 
-        # The data to send can be given either in @args[:content] (an array or string of raw data
-        # which MUST be in correct SMTP body format, including a trailing dot line), or a header and
-        # body given in @args[:header] and @args[:body].
+        # The data to send can be given in either @args[:message], @args[:content], or the
+        # combination of @args[:header] and @args[:body].
         #
-        if @args[:content]
+        #   - @args[:message] (String) MUST be a valid RFC2822 Internet Message
+        #
+        #   - @args[:content] (String) MUST be in correct SMTP body format, with escaped
+        #     leading dots and a trailing dot line
+        #
+        #   - @args[:header]  (Hash or String)
+        #   - @args[:body]    (Array or String)
+        if @args[:message]
+          send_data escape_leading_dots(@args[:message].to_s)
+          send_data "\r\n.\r\n"
+        elsif @args[:content]
           send_data @args[:content].to_s
         else
           # The header can be a hash or an array.
           if @args[:header].is_a?(Hash)
-            (@args[:header] || {}).each {|k,v| send_data "#{k}: #{v}\r\n" }
+            (@args[:header] || {}).each {|k,v| send_data escape_leading_dots("#{k}: #{v}\r\n") }
           else
-            send_data @args[:header].to_s
+            send_data escape_leading_dots(@args[:header].to_s)
           end
           send_data "\r\n"
 
           if @args[:body].is_a?(Array)
-            @args[:body].each {|e| send_data e}
+            @args[:body].each {|e| send_data escape_leading_dots(e)}
           else
-            send_data @args[:body].to_s
+            send_data escape_leading_dots(@args[:body].to_s)
           end
 
           send_data "\r\n.\r\n"

--- a/tests/test_smtpclient.rb
+++ b/tests/test_smtpclient.rb
@@ -52,4 +52,23 @@ class TestSmtpClient < Test::Unit::TestCase
     assert(err)
   end
 
+
+  EM::Protocols::SmtpClient.__send__(:public, :escape_leading_dots)
+
+  def test_escaping
+    smtp = EM::Protocols::SmtpClient.new :domain => "example.com"
+
+    expectations = {
+      "Hello\r\n" => "Hello\r\n",
+      "\r\n.whatever\r\n" => "\r\n..whatever\r\n",
+      "\r\n.\r\n" => "\r\n..\r\n",
+      "\r\n.\r\n." => "\r\n..\r\n..",
+      ".\r\n.\r\n" => "..\r\n..\r\n"
+    }
+
+    expectations.each do |input, output|
+      assert_equal output, smtp.escape_leading_dots(input)
+    end
+  end
+
 end


### PR DESCRIPTION
The DATA command of the SMTP protocol is terminated by a `\r\n.\r\n`. In order to allow for lines starting with a period or containing only a period, the protocol defines an escape mechanism. From [Section 4.5.2 of RFC5321](https://tools.ietf.org/html/rfc5321#section-4.5.2):

> Before sending a line of mail text, the SMTP client checks the first character of the line.  If it is a period, one additional period is inserted at the beginning of the line.

`EM::Protocols::SmtpClient` currently doesn't do this, and messages that contain the string `\r\n.\r\n` somewhere in the body will be truncated by SMTP servers. This is something we have encountered in the wild.

This PR does a few things:

1. Add `:message` as an additional option to SMTP client. This accepts a string that is a valid RFC2822 Internet Message. When using this option, `SmtpClient` will escape leading periods and add a trailing `\r\n.\r\n`.

2. Escape leading periods in `@args[:headers]` and `@args[:body]`. `@args[:content]` is not escaped because it expects data already in the proper format.

3. Update documentation:
  - Add documentation for `:message`
  - Remove documentation for `:content` being specified as an array, which isn't currently supported.
  - Specify that `:content` must included escaped leading periods in addition to a trailing `\r\n.\r\n`.
  - Replace MailFactory example with Mail example.
  - Remove outdated todo.
