### PR TITLE
SmtpClient: Unconditionally escape leading dots

### DIFF
--- a/lib/em/protocols/smtpclient.rb
+++ b/lib/em/protocols/smtpclient.rb
@@ -321,7 +321,7 @@ module EventMachine
       end
 
       def escape_leading_dots(s)
-        s.gsub(/^\.([^.]|$)/) { "..#{$1}" }
+        s.gsub(/^\./, '..')
       end
 
       def invoke_data

--- a/tests/test_smtpclient.rb
+++ b/tests/test_smtpclient.rb
@@ -63,7 +63,8 @@ class TestSmtpClient < Test::Unit::TestCase
       "\r\n.whatever\r\n" => "\r\n..whatever\r\n",
       "\r\n.\r\n" => "\r\n..\r\n",
       "\r\n.\r\n." => "\r\n..\r\n..",
-      ".\r\n.\r\n" => "..\r\n..\r\n"
+      ".\r\n.\r\n" => "..\r\n..\r\n",
+      "..\r\n" => "...\r\n"
     }
 
     expectations.each do |input, output|


### PR DESCRIPTION
Bug: emails sent using `:body` and `:headers` do not have leading dots properly escaped. This PR fixes that. See "Reasoning" below for more info.

## Breaking change

The `EM::Protocols::SmtpClient` `:body` and `:headers` parameters now escape leading dots on new lines.

Given the following message passed in as the `:body`

```
Hello
...world!
```

**Old behavior:** The message would be sent as-is. The recipient would see

```
Hello
..world!
```

**New behavior:** The leading dot in the second line would be escaped. The recipient would see

```
Hello
...world!
```

**Required updates to code:** If you knew about this issue and were working around it by manually escaping leading dots in data you passed to `:body` or `:headers`, you need to stop doing so to prevent double escaping. 

## Reasoning

cc/ @sodabrew 

While discussing #600, I wrote the following:

> The only change we made to the previous parameters was that leading dots in :body will now be escaped. This is not backwards-incompatible, however, because our escaping method is a no-op if the leading dots are already escaped.

Almost immediately after posting this, @davidbalbert and I realized that this decision was incorrect. Unfortunately, the PR had been merged before we could post. Sorry, @sodabrew!

The escaping mechanism for leading dots in the SMTP DATA command is unconditional. I.e. if a line starts with a dot, another dot should be inserted in front of it no matter what comes after. The current implementation escapes a leading dot only if it is not followed by another dot. This is a bug: it prevents a user from sending a message where a line starts with two leading dots (the recipient would see one), three leading dots (the recipient would see two), etc. This pull request fixes that behavior by unconditionally escaping any leading dot.

This is a small breaking change: If someone has been working around the lack of escaping in `:body` and `:headers` by escaping the leading dots themselves, this change will double-escape their leading dots. Given that `SmtpClient` has not been updated in years and to our knowledge no one had posted about the issue of unescaped leading dots, we think it's much more likely that people are unaware of this issue and sending unescaped emails via `:body` and `:headers` rather than manually escaping their emails themselves.