### PR TITLE
Postpone ArmKqueueWriter until all events are processed

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -466,8 +466,9 @@ void ConnectionDescriptor::_UpdateEvents(bool read, bool write)
 	#ifdef HAVE_KQUEUE
 	if (read && SelectForRead())
 		MyEventMachine->ArmKqueueReader (this);
-	if (write && SelectForWrite())
-		MyEventMachine->ArmKqueueWriter (this);
+	bKqueueArmWrite = SelectForWrite();
+	if (write && bKqueueArmWrite)
+		MyEventMachine->Modify (this);
 	#endif
 }
 
@@ -1501,8 +1502,9 @@ void AcceptorDescriptor::Read()
 		assert (MyEventMachine);
 		MyEventMachine->Add (cd);
 		#ifdef HAVE_KQUEUE
-		if (cd->SelectForWrite())
-			MyEventMachine->ArmKqueueWriter (cd);
+		bKqueueArmWrite = cd->SelectForWrite();
+		if (bKqueueArmWrite)
+			MyEventMachine->Modify (cd);
 		if (cd->SelectForRead())
 			MyEventMachine->ArmKqueueReader (cd);
 		#endif
@@ -1744,8 +1746,9 @@ void DatagramDescriptor::Write()
 	MyEventMachine->Modify (this);
 	#endif
 	#ifdef HAVE_KQUEUE
-	if (SelectForWrite())
-		MyEventMachine->ArmKqueueWriter (this);
+	bKqueueArmWrite = SelectForWrite();
+	assert (MyEventMachine);
+	MyEventMachine->Modify (this);
 	#endif
 }
 
@@ -1796,7 +1799,9 @@ int DatagramDescriptor::SendOutboundData (const char *data, unsigned long length
 	MyEventMachine->Modify (this);
 	#endif
 	#ifdef HAVE_KQUEUE
-	MyEventMachine->ArmKqueueWriter (this);
+	bKqueueArmWrite = true;
+	assert (MyEventMachine);
+	MyEventMachine->Modify (this);
 	#endif
 
 	return length;
@@ -1854,7 +1859,9 @@ int DatagramDescriptor::SendOutboundDatagram (const char *data, unsigned long le
 	MyEventMachine->Modify (this);
 	#endif
 	#ifdef HAVE_KQUEUE
-	MyEventMachine->ArmKqueueWriter (this);
+	bKqueueArmWrite = true;
+	assert (MyEventMachine);
+	MyEventMachine->Modify (this);
 	#endif
 
 	return length;

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -85,6 +85,10 @@ class EventableDescriptor: public Bindable_t
 		struct epoll_event *GetEpollEvent() { return &EpollEvent; }
 		#endif
 
+		#ifdef HAVE_KQUEUE
+		bool GetKqueueArmWrite() { return bKqueueArmWrite; }
+		#endif
+
 		virtual void StartProxy(const uintptr_t, const unsigned long, const unsigned long);
 		virtual void StopProxy();
 		virtual unsigned long GetProxiedBytes(){ return ProxiedBytes; };
@@ -124,6 +128,10 @@ class EventableDescriptor: public Bindable_t
 
 		#ifdef HAVE_EPOLL
 		struct epoll_event EpollEvent;
+		#endif
+
+		#ifdef HAVE_KQUEUE
+		bool bKqueueArmWrite;
 		#endif
 
 		EventMachine_t *MyEventMachine;

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1879,6 +1879,18 @@ void EventMachine_t::_ModifyDescriptors()
 	}
 	#endif
 
+	#ifdef HAVE_KQUEUE
+	if (Poller == Poller_Kqueue) {
+		set<EventableDescriptor*>::iterator i = ModifiedDescriptors.begin();
+		while (i != ModifiedDescriptors.end()) {
+			assert (*i);
+			if ((*i)->GetKqueueArmWrite())
+				ArmKqueueWriter (*i);
+			++i;
+		}
+	}
+	#endif
+
 	ModifiedDescriptors.clear();
 }
 


### PR DESCRIPTION
This PR implements the patch from #51. Tested on Mac OS X 10.10.4, where the original bug still occurs and the proposed patch resolves it.

Resolves #51, #176, #372, #401.