### PR TITLE
Fix unused arg warnings on -DWITHOUT_SSL

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1185,9 +1185,9 @@ void ConnectionDescriptor::StartTls()
 ConnectionDescriptor::SetTlsParms
 *********************************/
 
+#ifdef WITH_SSL
 void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer)
 {
-	#ifdef WITH_SSL
 	if (SslBox)
 		throw std::runtime_error ("call SetTlsParms before calling StartTls");
 	if (privkey_filename && *privkey_filename)
@@ -1195,12 +1195,15 @@ void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char
 	if (certchain_filename && *certchain_filename)
 		CertChainFilename = certchain_filename;
 	bSslVerifyPeer = verify_peer;
-	#endif
 
-	#ifdef WITHOUT_SSL
-	throw std::runtime_error ("Encryption not available on this event-machine");
-	#endif
 }
+#endif
+
+#ifdef WITHOUT_SSL
+void ConnectionDescriptor::SetTlsParms (const char *privkey_filename UNUSED, const char *certchain_filename UNUSED, bool verify_peer UNUSED) {
+	throw std::runtime_error ("Encryption not available on this event-machine");
+}
+#endif
 
 
 /*********************************

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -345,11 +345,11 @@ static VALUE t_set_tls_parms (VALUE self UNUSED, VALUE signature, VALUE privkeyf
 t_get_peer_cert
 ***************/
 
+#ifdef WITH_SSL
 static VALUE t_get_peer_cert (VALUE self UNUSED, VALUE signature)
 {
 	VALUE ret = Qnil;
 
-	#ifdef WITH_SSL
 	X509 *cert = NULL;
 	BUF_MEM *buf;
 	BIO *out;
@@ -364,10 +364,15 @@ static VALUE t_get_peer_cert (VALUE self UNUSED, VALUE signature)
 		X509_free(cert);
 		BIO_free(out);
 	}
-	#endif
 
 	return ret;
 }
+#else
+static VALUE t_get_peer_cert (VALUE self UNUSED, VALUE signature UNUSED)
+{
+	return Qnil;
+}
+#endif
 
 /**************
 t_get_peername
@@ -1381,4 +1386,3 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_const (EmModule, "SslHandshakeCompleted", INT2NUM(108));
 
 }
-


### PR DESCRIPTION
When installing the eventmachine gem on a system that doesn't have openssl, we see this error: 

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /usr/lib/rbenv/versions/2.1/bin/ruby extconf.rb
checking for main() in -lssl... no
checking for rb_trap_immediate in ruby.h,rubysig.h... no
checking for rb_thread_blocking_region()... yes
checking for ruby/thread.h... yes
checking for rb_thread_call_without_gvl() in ruby/thread.h... yes
checking for inotify_init() in sys/inotify.h... yes
checking for writev() in sys/uio.h... yes
checking for rb_thread_fd_select()... yes
checking for rb_fdset_t in ruby/intern.h... yes
checking for pipe2() in unistd.h... yes
checking for accept4() in sys/socket.h... yes
checking for SOCK_CLOEXEC in sys/socket.h... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enable_interrupt()... no
checking for rb_time_new()... yes
checking for sys/event.h... no
checking for epoll_create() in sys/epoll.h... yes
CFLAGS=$(cflags)  -fPIC -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-unused-result
CPPFLAGS= $(DEFS) $(cppflags) -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-unused-result
checking for clock_gettime()... no
checking for gethrtime()... no
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling binder.cpp
compiling cmain.cpp
compiling ed.cpp
ed.cpp:1227:6: error: unused parameter ‘privkey_filename’ [-Werror=unused-parameter]
 void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer)
      ^
ed.cpp:1227:6: error: unused parameter ‘certchain_filename’ [-Werror=unused-parameter]
ed.cpp:1227:6: error: unused parameter ‘verify_peer’ [-Werror=unused-parameter]
cc1plus: all warnings being treated as errors
make: *** [ed.o] Error 1

make failed, exit code 2
```

This is the result of the `WITHOUT_SSL` build not exercising the arguments in that list (and in another function, incidentally). In this pull req, I've introduced two new function definitions with `UNUSED` parameters in place. Hope this makes sense.