### PR TITLE
Switch from gethostbyname to getaddrinfo, support IPv6 addresses on Windows

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1838,9 +1838,9 @@ int DatagramDescriptor::SendOutboundDatagram (const char *data, unsigned long le
 	if (!address || !*address || !port)
 		return 0;
 
-	int family, addr_size;
-	struct sockaddr *addr_here = EventMachine_t::name2address (address, port, &family, &addr_size);
-	if (!addr_here)
+	struct sockaddr_in6 addr_here;
+	size_t addr_here_len = sizeof addr_here;
+	if (!EventMachine_t::name2address (address, port, (struct sockaddr *)&addr_here, &addr_here_len))
 		return -1;
 
 	if (!data && (length > 0))
@@ -1850,9 +1850,8 @@ int DatagramDescriptor::SendOutboundDatagram (const char *data, unsigned long le
 		throw std::runtime_error ("no allocation for outbound data");
 	memcpy (buffer, data, length);
 	buffer [length] = 0;
-	OutboundPages.push_back (OutboundPage (buffer, length, *(struct sockaddr_in6*)addr_here));
+	OutboundPages.push_back (OutboundPage (buffer, length, addr_here));
 	OutboundDataSize += length;
-	delete addr_here;
 
 	#ifdef HAVE_EPOLL
 	EpollEvent.events = (EPOLLIN | EPOLLOUT);

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -299,18 +299,18 @@ class DatagramDescriptor: public EventableDescriptor
 
 	protected:
 		struct OutboundPage {
-			OutboundPage (const char *b, int l, struct sockaddr_in f, int o=0): Buffer(b), Length(l), Offset(o), From(f) {}
+			OutboundPage (const char *b, int l, struct sockaddr_in6 f, int o=0): Buffer(b), Length(l), Offset(o), From(f) {}
 			void Free() {if (Buffer) free (const_cast<char*>(Buffer)); }
 			const char *Buffer;
 			int Length;
 			int Offset;
-			struct sockaddr_in From;
+			struct sockaddr_in6 From;
 		};
 
 		deque<OutboundPage> OutboundPages;
 		int OutboundDataSize;
 
-		struct sockaddr_in ReturnAddress;
+		struct sockaddr_in6 ReturnAddress;
 };
 
 

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1597,7 +1597,6 @@ struct sockaddr *name2address (const char *server, int port, int *family, int *b
 	}
 	#endif
 
-
 	struct addrinfo *ai;
 	if (getaddrinfo (server, NULL, NULL, &ai) == 0) {
 		if (family)

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1609,12 +1609,15 @@ struct sockaddr *name2address (const char *server, int port, int *family, int *b
 			case AF_INET:
 				memcpy(&in4, ai->ai_addr, ai->ai_addrlen);
 				in4.sin_port = htons(port);
-				return (struct sockaddr*)&in4;
+#ifndef CYGWIN
 			case AF_INET6:
 				memcpy(&in6, ai->ai_addr, ai->ai_addrlen);
 				in6.sin6_port = htons(port);
-				return (struct sockaddr*)&in6;
+#endif
 		}
+
+		freeaddrinfo(ai);
+		return (struct sockaddr*)&in4;
 	}
 
 	return NULL;

--- a/ext/em.h
+++ b/ext/em.h
@@ -200,10 +200,7 @@ class EventMachine_t
 
 		Poller_t GetPoller() { return Poller; }
 
-		/* Helper to convert strings to internet addresses. IPv6-aware.
-		 * Must delete the return value (or use an auto_ptr).
-		 */
-		static struct sockaddr *name2address(const char *server, int port, int *family, int *bind_size);
+		static bool name2address (const char *server, int port, struct sockaddr *addr, size_t *addr_len);
 
 	private:
 		void _RunTimers();

--- a/ext/em.h
+++ b/ext/em.h
@@ -200,6 +200,11 @@ class EventMachine_t
 
 		Poller_t GetPoller() { return Poller; }
 
+		/* Helper to convert strings to internet addresses. IPv6-aware.
+		 * Must delete the return value (or use an auto_ptr).
+		 */
+		static struct sockaddr *name2address(const char *server, int port, int *family, int *bind_size);
+
 	private:
 		void _RunTimers();
 		void _UpdateTime();

--- a/ext/project.h
+++ b/ext/project.h
@@ -30,6 +30,7 @@ See the file COPYING for complete licensing information.
 #include <string>
 #include <sstream>
 #include <stdexcept>
+#include <memory>
 
 
 #ifdef OS_UNIX

--- a/ext/project.h
+++ b/ext/project.h
@@ -30,7 +30,6 @@ See the file COPYING for complete licensing information.
 #include <string>
 #include <sstream>
 #include <stdexcept>
-#include <memory>
 
 
 #ifdef OS_UNIX

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -525,6 +525,8 @@ t_send_datagram
 static VALUE t_send_datagram (VALUE self UNUSED, VALUE signature, VALUE data, VALUE data_length, VALUE address, VALUE port)
 {
 	int b = evma_send_datagram (NUM2BSIG (signature), StringValuePtr (data), FIX2INT (data_length), StringValueCStr(address), FIX2INT(port));
+	if (b < 0)
+		rb_raise (EM_eConnectionError, "%s", "error in sending datagram"); // FIXME: this could be more specific.
 	return INT2NUM (b);
 }
 

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -31,6 +31,61 @@ class Test::Unit::TestCase
     @@port
   end
 
+  # Returns true if the host have a localhost 127.0.0.1 IPv4.
+  def self.local_ipv4?
+    return @@has_local_ipv4 if defined?(@@has_local_ipv4)
+    begin
+      get_my_ipv4_address "127.0.0.1"
+      @@has_local_ipv4 = true
+    rescue
+      @@has_local_ipv4 = false
+    end
+  end
+
+  # Returns true if the host have a public IPv4 and stores it in
+  # @@public_ipv4.
+  def self.public_ipv4?
+    return @@has_public_ipv4 if defined?(@@has_public_ipv4)
+    begin
+      @@public_ipv4 = get_my_ipv4_address "1.2.3.4"
+      @@has_public_ipv4 = true
+    rescue
+      @@has_public_ipv4 = false
+    end
+  end
+
+  # Returns true if the host have a localhost ::1 IPv6.
+  def self.local_ipv6?
+    return @@has_local_ipv6 if defined?(@@has_local_ipv6)
+    begin
+      get_my_ipv6_address "::1"
+      @@has_local_ipv6 = true
+    rescue
+      @@has_local_ipv6 = false
+    end
+  end
+
+  # Returns true if the host have a public IPv6 and stores it in
+  # @@public_ipv6.
+  def self.public_ipv6?
+    return @@has_public_ipv6 if defined?(@@has_public_ipv6)
+    begin
+      @@public_ipv6 = get_my_ipv6_address "2001::1"
+      @@has_public_ipv6 = true
+    rescue
+      @@has_public_ipv6 = false
+    end
+  end
+
+  # Returns an array with the localhost addresses (IPv4 and/or IPv6).
+  def local_ips
+    return @@local_ips if defined?(@@local_ips)
+    @@local_ips = []
+    @@local_ips << "127.0.0.1" if self.class.local_ipv4?
+    @@local_ips << "::1" if self.class.local_ipv6?
+    @@local_ips
+  end
+
   def exception_class
     jruby? ? NativeException : RuntimeError
   end
@@ -69,4 +124,28 @@ class Test::Unit::TestCase
       $VERBOSE = backup
     end
   end
+
+
+  private
+
+  def self.get_my_ipv4_address ip
+    orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true  # turn off reverse DNS resolution temporarily
+    UDPSocket.open(Socket::AF_INET) do |s|
+      s.connect ip, 1
+      s.addr.last
+    end
+  ensure
+    Socket.do_not_reverse_lookup = orig
+  end
+
+  def self.get_my_ipv6_address ip
+    orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true  # turn off reverse DNS resolution temporarily
+    UDPSocket.open(Socket::AF_INET6) do |s|
+      s.connect ip, 1
+      s.addr.last
+    end
+  ensure
+    Socket.do_not_reverse_lookup = orig
+  end
+
 end

--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -1,0 +1,125 @@
+require 'em_test_helper'
+require 'socket'
+
+class TestIPv4 < Test::Unit::TestCase
+
+  if Test::Unit::TestCase.public_ipv4?
+
+    # Tries to connect to www.google.com port 80 via TCP.
+    # Timeout in 2 seconds.
+    def test_ipv4_tcp_client
+      conn = nil
+      setup_timeout(2)
+
+      EM.run do
+        conn = EM::connect("www.google.com", 80) do |c|
+          def c.connected
+            @connected
+          end
+
+          def c.connection_completed
+            @connected = true
+            EM.stop
+          end
+        end
+      end
+
+      assert conn.connected
+    end
+
+    # Runs a TCP server in the local IPv4 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv4_tcp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+
+      EM.run do
+        EM::start_server(@@public_ipv4, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end
+        end
+
+        EM::connect(@@public_ipv4, @local_port) do |c|
+          c.send_data "ipv4/tcp"
+        end
+      end
+
+      assert_equal "ipv4/tcp", @@received_data
+    end
+
+    # Runs a UDP server in the local IPv4 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv4_udp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+
+      EM.run do
+        EM::open_datagram_socket(@@public_ipv4, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end
+        end
+
+        EM::open_datagram_socket(@@public_ipv4, next_port) do |c|
+          c.send_datagram "ipv4/udp", @@public_ipv4, @local_port
+        end
+      end
+
+      assert_equal "ipv4/udp", @@received_data
+    end
+
+    # Try to connect via TCP to an invalid IPv4. EM.connect should raise
+    # EM::ConnectionError.
+    def test_tcp_connect_to_invalid_ipv4
+      invalid_ipv4 = "9.9:9"
+
+      EM.run do
+        begin
+          error = nil
+          EM.connect(invalid_ipv4, 1234)
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
+    # Try to send a UDP datagram to an invalid IPv4. EM.send_datagram should raise
+    # EM::ConnectionError.
+    def test_udp_send_datagram_to_invalid_ipv4
+      invalid_ipv4 = "9.9:9"
+
+      EM.run do
+        begin
+          error = nil
+          EM.open_datagram_socket(@@public_ipv4, next_port) do |c|
+            c.send_datagram "hello", invalid_ipv4, 1234
+          end
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
+
+  else
+    warn "no IPv4 in this host, skipping tests in #{__FILE__}"
+
+    # Because some rubies will complain if a TestCase class has no tests
+    def test_ipv4_unavailable
+      assert true
+    end
+
+  end
+
+end

--- a/tests/test_ipv6.rb
+++ b/tests/test_ipv6.rb
@@ -1,0 +1,131 @@
+require 'em_test_helper'
+
+class TestIPv6 < Test::Unit::TestCase
+
+  if Test::Unit::TestCase.public_ipv6?
+
+    # Tries to connect to ipv6.google.com (2607:f8b0:4010:800::1006) port 80 via TCP.
+    # Timeout in 6 seconds.
+    def test_ipv6_tcp_client_with_ipv6_google_com
+      conn = nil
+      setup_timeout(6)
+
+      EM.run do
+        conn = EM::connect("2607:f8b0:4010:800::1006", 80) do |c|
+          def c.connected
+            @connected
+          end
+
+          def c.unbind(reason)
+            warn "unbind: #{reason.inspect}" if reason # XXX at least find out why it failed
+          end
+
+          def c.connection_completed
+            @connected = true
+            EM.stop
+          end
+        end
+      end
+
+      assert conn.connected
+    end
+
+    # Runs a TCP server in the local IPv6 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv6_tcp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+
+      EM.run do
+        EM.start_server(@@public_ipv6, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end
+        end
+
+        EM::connect(@@public_ipv6, @local_port) do |c|
+          def c.unbind(reason)
+            warn "unbind: #{reason.inspect}" if reason # XXX at least find out why it failed
+          end
+          c.send_data "ipv6/tcp"
+        end
+      end
+
+      assert_equal "ipv6/tcp", @@received_data
+    end
+
+    # Runs a UDP server in the local IPv6 address, connects to it and sends a specific data.
+    # Timeout in 2 seconds.
+    def test_ipv6_udp_local_server
+      @@received_data = nil
+      @local_port = next_port
+      setup_timeout(2)
+
+      EM.run do
+        EM.open_datagram_socket(@@public_ipv6, @local_port) do |s|
+          def s.receive_data data
+            @@received_data = data
+            EM.stop
+          end
+        end
+
+        EM.open_datagram_socket(@@public_ipv6, next_port) do |c|
+          c.send_datagram "ipv6/udp", @@public_ipv6, @local_port
+        end
+      end
+
+      assert_equal "ipv6/udp", @@received_data
+    end
+
+    # Try to connect via TCP to an invalid IPv6. EM.connect should raise
+    # EM::ConnectionError.
+    def test_tcp_connect_to_invalid_ipv6
+      invalid_ipv6 = "1:A"
+
+      EM.run do
+        begin
+          error = nil
+          EM.connect(invalid_ipv6, 1234)
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
+    # Try to send a UDP datagram to an invalid IPv6. EM.send_datagram should raise
+    # EM::ConnectionError.
+    def test_udp_send_datagram_to_invalid_ipv6
+      invalid_ipv6 = "1:A"
+
+      EM.run do
+        begin
+          error = nil
+          EM.open_datagram_socket(@@public_ipv6, next_port) do |c|
+            c.send_datagram "hello", invalid_ipv6, 1234
+          end
+        rescue => e
+          error = e
+        ensure
+          EM.stop
+          assert_equal EM::ConnectionError, (error && error.class)
+        end
+      end
+    end
+
+
+  else
+    warn "no IPv6 in this host, skipping tests in #{__FILE__}"
+
+    # Because some rubies will complain if a TestCase class has no tests.
+    def test_ipv6_unavailable
+      assert true
+    end
+
+  end
+
+end


### PR DESCRIPTION
Resolves #595 by merging and improving upon ibc/eventmachine-le#27 and ibc/eventmachine-le#28
With thanks to @mpalmer for the getaddrinfo implementation in eventmachine-le.