### PR TITLE
Use WSAStringToAddress in lieu of inet_pton for IPv6 address detection on Windows

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1196,7 +1196,7 @@ const uintptr_t EventMachine_t::ConnectToServer (const char *bind_addr, int bind
 		throw std::runtime_error ("invalid server or port");
 
 	int family, bind_size;
-	struct sockaddr bind_as, *bind_as_ptr = name2address (server, port, &family, &bind_size);
+	struct sockaddr_storage bind_as, *bind_as_ptr = (struct sockaddr_storage*)name2address (server, port, &family, &bind_size);
 	if (!bind_as_ptr) {
 		char buf [200];
 		snprintf (buf, sizeof(buf)-1, "unable to resolve server address: %s", strerror(errno));
@@ -1241,7 +1241,7 @@ const uintptr_t EventMachine_t::ConnectToServer (const char *bind_addr, int bind
 	#ifdef OS_UNIX
 	int e_reason = 0;
 	//if (connect (sd, (sockaddr*)&pin, sizeof pin) == 0) {
-	if (connect (sd, &bind_as, bind_size) == 0) {
+	if (connect (sd, (struct sockaddr*)&bind_as, bind_size) == 0) {
 		// This is a connect success, which Linux appears
 		// never to give when the socket is nonblocking,
 		// even if the connection is intramachine or to


### PR DESCRIPTION
Resolves #595 