### PR TITLE
Two tiny tweaks for grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This unique combination makes EventMachine a premier choice for designers of cri
 applications, including Web servers and proxies, email and IM production systems, authentication/authorization
 processors, and many more.
 
-EventMachine has been around since the early 2000s and is a mature and battle tested library.
+EventMachine has been around since the early 2000s and is a mature and battle-tested library.
 
 
 ## What EventMachine is good for? ##

--- a/lib/em/completion.rb
+++ b/lib/em/completion.rb
@@ -1,7 +1,7 @@
 # = EM::Completion
 #
 # A completion is a callback container for various states of completion. In
-# it's most basic form it has a start state and a finish state.
+# its most basic form it has a start state and a finish state.
 #
 # This implementation includes some hold-back from the EM::Deferrable
 # interface in order to be compatible - but it has a much cleaner
@@ -50,7 +50,7 @@
 #          @completion.fail :unknown, line
 #        end
 #      end
-#  
+#
 #      def unbind
 #        @completion.fail :disconnected unless @completion.completed?
 #      end


### PR DESCRIPTION
Hyphenated a compound adjective. Corrected “it’s” to “its”.