### PR TITLE
Replace Exception class with StandardError

### DIFF
--- a/ext/fastfilereader/rubymain.cpp
+++ b/ext/fastfilereader/rubymain.cpp
@@ -50,7 +50,7 @@ static VALUE mapper_new (VALUE self, VALUE filename)
 {
 	Mapper_t *m = new Mapper_t (StringValueCStr (filename));
 	if (!m)
-		rb_raise (rb_eException, "No Mapper Object");
+		rb_raise (rb_eStandardError, "No Mapper Object");
 	VALUE v = Data_Wrap_Struct (Mapper, 0, mapper_dt, (void*)m);
 	return v;
 }
@@ -65,17 +65,17 @@ static VALUE mapper_get_chunk (VALUE self, VALUE start, VALUE length)
 	Mapper_t *m = NULL;
 	Data_Get_Struct (self, Mapper_t, m);
 	if (!m)
-		rb_raise (rb_eException, "No Mapper Object");
+		rb_raise (rb_eStandardError, "No Mapper Object");
 
 	// TODO, what if some moron sends us a negative start value?
 	unsigned _start = NUM2INT (start);
 	unsigned _length = NUM2INT (length);
 	if ((_start + _length) > m->GetFileSize())
-		rb_raise (rb_eException, "Mapper Range Error");
+		rb_raise (rb_eStandardError, "Mapper Range Error");
 
 	const char *chunk = m->GetChunk (_start);
 	if (!chunk)
-		rb_raise (rb_eException, "No Mapper Chunk");
+		rb_raise (rb_eStandardError, "No Mapper Chunk");
 	return rb_str_new (chunk, _length);
 }
 
@@ -88,7 +88,7 @@ static VALUE mapper_close (VALUE self)
 	Mapper_t *m = NULL;
 	Data_Get_Struct (self, Mapper_t, m);
 	if (!m)
-		rb_raise (rb_eException, "No Mapper Object");
+		rb_raise (rb_eStandardError, "No Mapper Object");
 	m->Close();
 	return Qnil;
 }
@@ -102,7 +102,7 @@ static VALUE mapper_size (VALUE self)
 	Mapper_t *m = NULL;
 	Data_Get_Struct (self, Mapper_t, m);
 	if (!m)
-		rb_raise (rb_eException, "No Mapper Object");
+		rb_raise (rb_eStandardError, "No Mapper Object");
 	return INT2NUM (m->GetFileSize());
 }
 

--- a/lib/em/pool.rb
+++ b/lib/em/pool.rb
@@ -143,7 +143,7 @@ module EventMachine
       else
         raise ArgumentError, "deferrable expected from work"
       end
-    rescue Exception
+    rescue
       failure resource
       raise
     end

--- a/lib/em/protocols/line_and_text.rb
+++ b/lib/em/protocols/line_and_text.rb
@@ -45,7 +45,7 @@ module EventMachine
             @lpb_buffer.extract(data).each do |line|
               receive_line(line.chomp) if respond_to?(:receive_line)
             end
-          rescue Exception
+          rescue
             receive_error('overlength line') if respond_to?(:receive_error)
             close_connection
             return

--- a/lib/em/threaded_resource.rb
+++ b/lib/em/threaded_resource.rb
@@ -71,7 +71,7 @@ module EventMachine
         begin
           result = yield @resource
           completion.succeed result
-        rescue Exception => e
+        rescue => e
           completion.fail e
         end
       end


### PR DESCRIPTION
Don't raise/rescue Exception classes, use StandardError instead.

https://robots.thoughtbot.com/rescue-standarderror-not-exception
https://www.relishapp.com/womply/ruby-style-guide/docs/exceptions
http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby/10048406#10048406