### PR TITLE
Restore silent-fail on unsupported EM.epoll and EM.kqueue

### DIFF
--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -997,10 +997,8 @@ t__epoll
 
 static VALUE t__epoll (VALUE self UNUSED)
 {
-	if (t__epoll_p(self) == Qfalse) {
-		rb_warn ("epoll is not supported on this platform");
+	if (t__epoll_p(self) == Qfalse)
 		return Qfalse;
-	}
 
 	evma_set_epoll (1);
 	return Qtrue;
@@ -1012,8 +1010,8 @@ t__epoll_set
 
 static VALUE t__epoll_set (VALUE self, VALUE val)
 {
-	if (t__epoll_p(self) == Qfalse)
-		rb_warn ("epoll is not supported on this platform");
+	if (t__epoll_p(self) == Qfalse && val == Qtrue)
+		rb_raise (EM_eUnsupported, "%s", "epoll is not supported on this platform");
 
 	evma_set_epoll (val == Qtrue ? 1 : 0);
 	return val;
@@ -1039,10 +1037,8 @@ t__kqueue
 
 static VALUE t__kqueue (VALUE self UNUSED)
 {
-	if (t__kqueue_p(self) == Qfalse) {
-		rb_warn ("kqueue is not supported on this platform");
+	if (t__kqueue_p(self) == Qfalse)
 		return Qfalse;
-	}
 
 	evma_set_kqueue (1);
 	return Qtrue;
@@ -1054,8 +1050,8 @@ t__kqueue_set
 
 static VALUE t__kqueue_set (VALUE self, VALUE val)
 {
-	if (t__kqueue_p(self) == Qfalse)
-		rb_warn ("kqueue is not supported on this platform");
+	if (t__kqueue_p(self) == Qfalse && val == Qtrue)
+		rb_raise (EM_eUnsupported, "%s", "kqueue is not supported on this platform");
 
 	evma_set_kqueue (val == Qtrue ? 1 : 0);
 	return val;


### PR DESCRIPTION
raise on unsupported EM.epoll=true and EM.kqueue=true

Follows up on 9af9406 and #638