### PR TITLE
Older MinGW in the Ruby Dev Kit does not define the getaddrinfo hints

### DIFF
--- a/ext/pipe.cpp
+++ b/ext/pipe.cpp
@@ -229,6 +229,11 @@ void PipeDescriptor::Write()
 
 	assert (GetSocket() != INVALID_SOCKET);
 	int bytes_written = write (GetSocket(), output_buffer, nbytes);
+#ifdef OS_WIN32
+	int e = WSAGetLastError();
+#else
+	int e = errno;
+#endif
 
 	if (bytes_written > 0) {
 		OutboundDataSize -= bytes_written;
@@ -251,10 +256,10 @@ void PipeDescriptor::Write()
 	}
 	else {
 		#ifdef OS_UNIX
-		if ((errno != EINPROGRESS) && (errno != EWOULDBLOCK) && (errno != EINTR))
+		if ((e != EINPROGRESS) && (e != EWOULDBLOCK) && (e != EINTR))
 		#endif
 		#ifdef OS_WIN32
-		if ((errno != WSAEINPROGRESS) && (errno != WSAEWOULDBLOCK))
+		if ((e != WSAEINPROGRESS) && (e != WSAEWOULDBLOCK))
 		#endif
 			Close();
 	}

--- a/ext/project.h
+++ b/ext/project.h
@@ -96,6 +96,15 @@ typedef int SOCKET;
 #include <fcntl.h>
 #include <assert.h>
 
+// Older versions of MinGW in the Ruby Dev Kit do not provide the getaddrinfo hint flags
+#ifndef AI_ADDRCONFIG
+#define AI_ADDRCONFIG  0x0400
+#endif
+
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0x0008
+#endif
+
 // Use the Win32 wrapper library that Ruby owns to be able to close sockets with the close() function
 #define RUBY_EXPORT
 #include <ruby/defines.h>


### PR DESCRIPTION
The doc clearly show that these should be available https://msdn.microsoft.com/en-us/library/windows/desktop/ms738520(v=vs.85).aspx

... AHA! The headers are coming from MingW, and until recently did not provide these values.
http://sourceforge.net/p/mingw-w64/mailman/message/33056995/