### PR TITLE
Allow reusing of datagram socket/setting bind device

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1644,6 +1644,12 @@ const uintptr_t EventMachine_t::OpenDatagramSocket (const char *address, int por
 	if (sd == INVALID_SOCKET)
 		goto fail;
 
+	{ // set the SO_REUSEADDR on the socket before we bind, otherwise it won't work for a second one
+		int oval = 1;
+		if (setsockopt (sd, SOL_SOCKET, SO_REUSEADDR, (char*)&oval, sizeof(oval)) < 0)
+			goto fail;
+	}
+
 	// Set the new socket nonblocking.
 	if (!SetSocketNonblocking (sd))
 		goto fail;


### PR DESCRIPTION
- create new function open_datagram_socket_with_reuseaddr
  - the SO_REUSEADDR flag needs to be set before we call the bind on the socket
- add the support to be able to set_sock_opt with SO_BINDTODEVICE
  - this takes in a struct with an interface name set inside of it