### PR TITLE
Try more ways to detect OpenSSL, including MacPorts and HomeBrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,37 @@
 bundler_args: --without documentation
 script: bundle exec rake compile test
+before_install:
+  - 'if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install openssl; fi'
 env:
   global:
     - TESTOPTS=-v
 language: ruby
 sudo: false
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1
+  - 2.3.0
   - 2.2
+  - 2.1
+  - 2.0.0
+  - 1.9.3
+  - 1.9.2
+  - 1.8.7
   - ruby-head
   - rbx
-  - jruby-1.7
-  - jruby-9
+  - rbx-2
+#  - jruby-1.7
+#  - jruby-9
 matrix:
   allow_failures:
-    - rvm: ruby-head
     - rvm: rbx
-    - rvm: jruby-1.7
-    - rvm: jruby-9
+    - rvm: rbx-2
+    - rvm: ruby-head
+    - rvm: 2.0.0
+    - rvm: 2.0.0
+      os: osx
+      osx_image: xcode7.2
+#    - rvm: jruby-1.7
+#    - rvm: jruby-9
   include:
     - rvm: 2.0.0
       os: osx
+      osx_image: xcode7.2

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1524,7 +1524,7 @@ void AcceptorDescriptor::Read()
 	int accept_count = EventMachine_t::GetSimultaneousAcceptCount();
 
 	for (int i=0; i < accept_count; i++) {
-#if defined(HAVE_SOCK_CLOEXEC) && defined(HAVE_ACCEPT4)
+#if defined(HAVE_CONST_SOCK_CLOEXEC) && defined(HAVE_ACCEPT4)
 		SOCKET sd = accept4 (GetSocket(), (struct sockaddr*)&pin, &addrlen, SOCK_CLOEXEC);
 		if (sd == INVALID_SOCKET) {
 			// We may be running in a kernel where

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -912,7 +912,7 @@ SelectData_t::~SelectData_t()
 _SelectDataSelect
 *****************/
 
-#if defined(HAVE_TBR) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
+#if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
 static VALUE _SelectDataSelect (void *v)
 {
 	SelectData_t *sd = (SelectData_t*)v;

--- a/ext/em.h
+++ b/ext/em.h
@@ -37,7 +37,7 @@ See the file COPYING for complete licensing information.
     #include <ruby/io.h>
   #endif
 
-  #if defined(HAVE_RBTRAP)
+  #if defined(HAVE_RB_TRAP_IMMEDIATE)
     #include <rubysig.h>
   #elif defined(HAVE_RB_ENABLE_INTERRUPT)
     extern "C" {
@@ -69,7 +69,7 @@ See the file COPYING for complete licensing information.
   #define EmSelect select
 #endif
 
-#if !defined(HAVE_RB_FDSET_T)
+#if !defined(HAVE_TYPE_RB_FDSET_T)
 #define fd_check(n) (((n) < FD_SETSIZE) ? 1 : 0*fprintf(stderr, "fd %d too large for select\n", (n)))
 // These definitions are cribbed from include/ruby/intern.h in Ruby 1.9.3,
 // with this change: any macros that read or write the nth element of an

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,6 +1,9 @@
 require 'fileutils'
 require 'mkmf'
 
+# Eager check devs tools
+have_devel? if respond_to?(:have_devel?)
+
 def check_libs libs = [], fatal = false
   libs.all? { |lib| have_library(lib) || (abort("could not find library: #{lib}") if fatal) }
 end
@@ -22,34 +25,58 @@ def append_library(libs, lib)
   libs + " " + format(LIBARG, lib)
 end
 
-def manual_ssl_config
-  ssl_libs_heads_args = {
-    :unix => [%w[ssl crypto], %w[openssl/ssl.h openssl/err.h]],
-    :mswin => [%w[ssleay32 libeay32], %w[openssl/ssl.h openssl/err.h]],
-  }
-
-  dc_flags = ['ssl']
-  dc_flags += ["#{ENV['OPENSSL']}/include", ENV['OPENSSL']] if /linux/ =~ RUBY_PLATFORM and ENV['OPENSSL']
-
-  libs, heads = case RUBY_PLATFORM
-  when /mswin|mingw|bccwin/ ; ssl_libs_heads_args[:mswin]
-  else                        ssl_libs_heads_args[:unix]
-  end
-  dir_config(*dc_flags)
-  check_libs(libs) and check_heads(heads)
+SSL_HEADS = %w(openssl/ssl.h openssl/err.h)
+SSL_LIBS = case RUBY_PLATFORM
+when /mswin|mingw|bccwin/ ; %w(ssleay32 libeay32)
+else                      ; %w(crypto ssl)
 end
 
-# Eager check devs tools
-have_devel? if respond_to?(:have_devel?)
+def dir_config_wrapper(pretty_name, name, idefault=nil, ldefault=nil)
+  inc, lib = dir_config(name, idefault, ldefault)
+  if inc && lib
+    # TODO: Remove when 2.0.0 is the minimum supported version
+    # Ruby versions not incorporating the mkmf fix at
+    # https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717
+    # do not properly search for lib directories, and must be corrected
+    unless lib && lib[-3, 3] == 'lib'
+      @libdir_basename = 'lib'
+      inc, lib = dir_config(name, idefault, ldefault)
+    end
+    unless idefault && ldefault
+      abort "-----\nCannot find #{pretty_name} include path #{inc}\n-----" unless inc && inc.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
+      abort "-----\nCannot find #{pretty_name} library path #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
+      warn "-----\nUsing #{pretty_name} in path #{File.dirname inc}\n-----"
+    end
+    true
+  end
+end
+
+def dir_config_search(pretty_name, name, paths, &b)
+  paths.each do |p|
+    if dir_config_wrapper('OpenSSL', 'ssl', p + '/include', p + '/lib') && yield
+      warn "-----\nFound #{pretty_name} in path #{p}\n-----"
+      return true
+    end
+  end
+end
+
+def pkg_config_wrapper(pretty_name, name)
+  cflags, ldflags, libs = pkg_config(name)
+  unless [cflags, ldflags, libs].any?(&:nil?) || [cflags, ldflags, libs].any?(&:empty?)
+    warn "-----\nUsing #{pretty_name} from pkg-config #{cflags} && #{ldflags} && #{libs}\n-----"
+    true
+  end
+end
 
 if ENV['CROSS_COMPILING']
-  openssl_version = ENV.fetch("OPENSSL_VERSION", "1.0.1i")
+  openssl_version = ENV.fetch("OPENSSL_VERSION", "1.0.2e")
   openssl_dir = File.expand_path("~/.rake-compiler/builds/openssl-#{openssl_version}/")
   if File.exist?(openssl_dir)
     FileUtils.mkdir_p Dir.pwd+"/openssl/"
     FileUtils.cp Dir[openssl_dir+"/include/openssl/*.h"], Dir.pwd+"/openssl/", :verbose => true
     FileUtils.cp Dir[openssl_dir+"/lib*.a"], Dir.pwd, :verbose => true
     $INCFLAGS << " -I#{Dir.pwd}" # for the openssl headers
+    add_define "WITH_SSL"
   else
     STDERR.puts
     STDERR.puts "**************************************************************************************"
@@ -58,11 +85,20 @@ if ENV['CROSS_COMPILING']
     STDERR.puts "**************************************************************************************"
     STDERR.puts
   end
-end
-
-# Try to use pkg_config first, fixes #73
-if (!ENV['CROSS_COMPILING'] and pkg_config('openssl')) || manual_ssl_config
-  add_define "WITH_SSL"
+elsif dir_config_wrapper('OpenSSL', 'ssl')
+  # If the user has provided a --with-ssl-dir argument, we must respect it or fail.
+  add_define 'WITH_SSL' if check_libs(SSL_LIBS) && check_heads(SSL_HEADS)
+elsif pkg_config_wrapper('OpenSSL', 'openssl')
+  # If we can detect OpenSSL by pkg-config, use it as the next-best option
+  add_define 'WITH_SSL' if check_libs(SSL_LIBS) && check_heads(SSL_HEADS)
+elsif check_libs(SSL_LIBS) && check_heads(SSL_HEADS)
+  # If we don't even need any options to find a usable OpenSSL, go with it
+  add_define 'WITH_SSL'
+elsif dir_config_search('OpenSSL', 'ssl', ['/usr/local', '/opt/local', '/usr/local/opt/openssl']) do
+    check_libs(SSL_LIBS) && check_heads(SSL_HEADS)
+  end
+  # Finally, look for OpenSSL in alternate locations including MacPorts and HomeBrew
+  add_define 'WITH_SSL'
 end
 
 add_define 'BUILD_FOR_RUBY'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -102,21 +102,26 @@ elsif dir_config_search('OpenSSL', 'ssl', ['/usr/local', '/opt/local', '/usr/loc
 end
 
 add_define 'BUILD_FOR_RUBY'
-add_define 'HAVE_RBTRAP' if have_var('rb_trap_immediate', ['ruby.h', 'rubysig.h'])
-add_define "HAVE_TBR" if have_func('rb_thread_blocking_region')# and have_macro('RUBY_UBF_IO', 'ruby.h')
-add_define "HAVE_RB_THREAD_CALL_WITHOUT_GVL" if have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
-add_define "HAVE_INOTIFY" if inotify = have_func('inotify_init', 'sys/inotify.h')
-add_define "HAVE_OLD_INOTIFY" if !inotify && have_macro('__NR_inotify_init', 'sys/syscall.h')
-add_define 'HAVE_WRITEV' if have_func('writev', 'sys/uio.h')
-add_define 'HAVE_RB_THREAD_FD_SELECT' if have_func('rb_thread_fd_select')
-add_define 'HAVE_RB_FDSET_T' if have_type('rb_fdset_t', 'ruby/intern.h')
-add_define 'HAVE_PIPE2' if have_func('pipe2', 'unistd.h')
-add_define 'HAVE_ACCEPT4' if have_func('accept4', 'sys/socket.h')
-add_define 'HAVE_SOCK_CLOEXEC' if have_const('SOCK_CLOEXEC', 'sys/socket.h')
 
+# Ruby features:
+
+have_var('rb_trap_immediate', ['ruby.h', 'rubysig.h'])
+have_func('rb_thread_blocking_region')
+have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
+have_func('rb_thread_fd_select')
+have_type('rb_fdset_t', 'ruby/intern.h')
 have_func('rb_wait_for_single_fd')
 have_func('rb_enable_interrupt')
 have_func('rb_time_new')
+
+# System features:
+
+add_define('HAVE_INOTIFY') if inotify = have_func('inotify_init', 'sys/inotify.h')
+add_define('HAVE_OLD_INOTIFY') if !inotify && have_macro('__NR_inotify_init', 'sys/syscall.h')
+have_func('writev', 'sys/uio.h')
+have_func('pipe2', 'unistd.h')
+have_func('accept4', 'sys/socket.h')
+have_const('SOCK_CLOEXEC', 'sys/socket.h')
 
 # Minor platform details between *nix and Windows:
 
@@ -129,7 +134,7 @@ else
   OS_UNIX = true
   add_define 'OS_UNIX'
 
-  add_define "HAVE_KQUEUE" if have_header("sys/event.h") and have_header("sys/queue.h")
+  add_define "HAVE_KQUEUE" if have_header("sys/event.h") && have_header("sys/queue.h")
 end
 
 # Adjust number of file descriptors (FD) on Windows
@@ -161,7 +166,7 @@ when /solaris/
 
   # If Ruby was compiled for 32-bits, then select() can only handle 1024 fds
   # There is an alternate function, select_large_fdset, that supports more.
-  add_define 'HAVE_SELECT_LARGE_FDSET' if have_func('select_large_fdset', 'sys/select.h')
+  have_func('select_large_fdset', 'sys/select.h')
 
   if CONFIG['CC'] == 'cc' && (
      `cc -flags 2>&1` =~ /Sun/ || # detect SUNWspro compiler


### PR DESCRIPTION
Resolves #661 by detecting OpenSSL in the default MacPorts and HomeBrew paths.