### PR TITLE
Rename SSL protocols field to ssl_version for consistency

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -459,12 +459,12 @@ extern "C" void evma_start_tls (const uintptr_t binding)
 evma_set_tls_parms
 ******************/
 
-extern "C" void evma_set_tls_parms (const uintptr_t binding, const char *privatekey_filename, const char *certchain_filename, int verify_peer, int fail_if_no_peer_cert, const char *sni_hostname, const char *cipherlist, const char *ecdh_curve, const char *dhparam, int protocols)
+extern "C" void evma_set_tls_parms (const uintptr_t binding, const char *privatekey_filename, const char *certchain_filename, int verify_peer, int fail_if_no_peer_cert, const char *sni_hostname, const char *cipherlist, const char *ecdh_curve, const char *dhparam, int ssl_version)
 {
 	ensure_eventmachine("evma_set_tls_parms");
 	EventableDescriptor *ed = dynamic_cast <EventableDescriptor*> (Bindable_t::GetObject (binding));
 	if (ed)
-		ed->SetTlsParms (privatekey_filename, certchain_filename, (verify_peer == 1 ? true : false), (fail_if_no_peer_cert == 1 ? true : false), sni_hostname, cipherlist, ecdh_curve, dhparam, protocols);
+		ed->SetTlsParms (privatekey_filename, certchain_filename, (verify_peer == 1 ? true : false), (fail_if_no_peer_cert == 1 ? true : false), sni_hostname, cipherlist, ecdh_curve, dhparam, ssl_version);
 }
 
 /******************

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -341,14 +341,14 @@ static VALUE t_start_tls (VALUE self UNUSED, VALUE signature)
 t_set_tls_parms
 ***************/
 
-static VALUE t_set_tls_parms (VALUE self UNUSED, VALUE signature, VALUE privkeyfile, VALUE certchainfile, VALUE verify_peer, VALUE fail_if_no_peer_cert, VALUE snihostname, VALUE cipherlist, VALUE ecdh_curve, VALUE dhparam, VALUE protocols)
+static VALUE t_set_tls_parms (VALUE self UNUSED, VALUE signature, VALUE privkeyfile, VALUE certchainfile, VALUE verify_peer, VALUE fail_if_no_peer_cert, VALUE snihostname, VALUE cipherlist, VALUE ecdh_curve, VALUE dhparam, VALUE ssl_version)
 {
 	/* set_tls_parms takes a series of positional arguments for specifying such things
 	 * as private keys and certificate chains.
 	 * It's expected that the parameter list will grow as we add more supported features.
 	 * ALL of these parameters are optional, and can be specified as empty or NULL strings.
 	 */
-	evma_set_tls_parms (NUM2BSIG (signature), StringValueCStr (privkeyfile), StringValueCStr (certchainfile), (verify_peer == Qtrue ? 1 : 0), (fail_if_no_peer_cert == Qtrue ? 1 : 0), StringValueCStr (snihostname), StringValueCStr (cipherlist), StringValueCStr (ecdh_curve), StringValueCStr (dhparam), NUM2INT (protocols));
+	evma_set_tls_parms (NUM2BSIG (signature), StringValueCStr (privkeyfile), StringValueCStr (certchainfile), (verify_peer == Qtrue ? 1 : 0), (fail_if_no_peer_cert == Qtrue ? 1 : 0), StringValueCStr (snihostname), StringValueCStr (cipherlist), StringValueCStr (ecdh_curve), StringValueCStr (dhparam), NUM2INT (ssl_version));
 	return Qnil;
 }
 

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -120,7 +120,7 @@ static void InitializeDefaultCredentials()
 SslContext_t::SslContext_t
 **************************/
 
-SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int protocols) :
+SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version) :
 	bIsServer (is_server),
 	pCtx (NULL),
 	PrivateKey (NULL),
@@ -161,22 +161,22 @@ SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const str
 	# endif
 	#endif
 
-	if (!(protocols & EM_PROTO_SSLv2))
+	if (!(ssl_version & EM_PROTO_SSLv2))
 		SSL_CTX_set_options (pCtx, SSL_OP_NO_SSLv2);
 
-	if (!(protocols & EM_PROTO_SSLv3))
+	if (!(ssl_version & EM_PROTO_SSLv3))
 		SSL_CTX_set_options (pCtx, SSL_OP_NO_SSLv3);
 
-	if (!(protocols & EM_PROTO_TLSv1))
+	if (!(ssl_version & EM_PROTO_TLSv1))
 		SSL_CTX_set_options (pCtx, SSL_OP_NO_TLSv1);
 
 	#ifdef SSL_OP_NO_TLSv1_1
-	if (!(protocols & EM_PROTO_TLSv1_1))
+	if (!(ssl_version & EM_PROTO_TLSv1_1))
 		SSL_CTX_set_options (pCtx, SSL_OP_NO_TLSv1_1);
 	#endif
 
 	#ifdef SSL_OP_NO_TLSv1_2
-	if (!(protocols & EM_PROTO_TLSv1_2))
+	if (!(ssl_version & EM_PROTO_TLSv1_2))
 		SSL_CTX_set_options (pCtx, SSL_OP_NO_TLSv1_2);
 	#endif
 
@@ -304,7 +304,7 @@ SslContext_t::~SslContext_t()
 SslBox_t::SslBox_t
 ******************/
 
-SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const string &snihostname, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int protocols, const uintptr_t binding):
+SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const string &snihostname, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version, const uintptr_t binding):
 	bIsServer (is_server),
 	bHandshakeCompleted (false),
 	bVerifyPeer (verify_peer),
@@ -317,7 +317,7 @@ SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &cer
 	 * a new one every time we come here.
 	 */
 
-	Context = new SslContext_t (bIsServer, privkeyfile, certchainfile, cipherlist, ecdh_curve, dhparam, protocols);
+	Context = new SslContext_t (bIsServer, privkeyfile, certchainfile, cipherlist, ecdh_curve, dhparam, ssl_version);
 	assert (Context);
 
 	pbioRead = BIO_new (BIO_s_mem());

--- a/ext/ssl.h
+++ b/ext/ssl.h
@@ -33,7 +33,7 @@ class SslContext_t
 class SslContext_t
 {
 	public:
-		SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int protocols);
+		SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version);
 		virtual ~SslContext_t();
 
 	private:
@@ -61,7 +61,7 @@ class SslBox_t
 class SslBox_t
 {
 	public:
-		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const string &snihostname, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int protocols, const uintptr_t binding);
+		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const string &snihostname, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version, const uintptr_t binding);
 		virtual ~SslBox_t();
 
 		int PutPlaintext (const char*, int);

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -389,7 +389,7 @@ module EventMachine
     #
     # @option args [String] :dhparam (nil)  The local path of a file containing DH parameters for EDH ciphers in [PEM format](http://en.wikipedia.org/wiki/Privacy_Enhanced_Mail) See: 'openssl dhparam'
     #
-    # @option args [Array] :protocols (TLSv1 TLSv1.1 TLSv1.2) indicates the allowed SSL/TLS protocols versions. Possible values are: {SSLv2}, {SSLv3}, {TLSv1}, {TLSv1.1}, {TLSv1.2}.
+    # @option args [Array] :ssl_version (TLSv1 TLSv1_1 TLSv1_2) indicates the allowed SSL/TLS versions. Possible values are: {SSLv2}, {SSLv3}, {TLSv1}, {TLSv1_1}, {TLSv1_2}.
     #
     # @example Using TLS with EventMachine
     #
@@ -415,7 +415,15 @@ module EventMachine
     #
     # @see #ssl_verify_peer
     def start_tls args={}
-      priv_key, cert_chain, verify_peer, fail_if_no_peer_cert, sni_hostname, cipher_list, ecdh_curve, dhparam, protocols = args.values_at(:private_key_file, :cert_chain_file, :verify_peer, :fail_if_no_peer_cert, :sni_hostname, :cipher_list, :ecdh_curve, :dhparam, :protocols)
+      priv_key     = args[:private_key_file]
+      cert_chain   = args[:cert_chain_file]
+      verify_peer  = args[:verify_peer]
+      sni_hostname = args[:sni_hostname]
+      cipher_list  = args[:cipher_list]
+      ssl_version  = args[:ssl_version]
+      ecdh_curve   = args[:ecdh_curve]
+      dhparam      = args[:dhparam]
+      fail_if_no_peer_cert = args[:fail_if_no_peer_cert]
 
       [priv_key, cert_chain].each do |file|
         next if file.nil? or file.empty?
@@ -424,23 +432,22 @@ module EventMachine
       end
 
       protocols_bitmask = 0
-      if protocols.nil?
+      if ssl_version.nil?
         protocols_bitmask |= EventMachine::EM_PROTO_TLSv1
         protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_1
         protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_2
       else
-        protocols ||= []
-        protocols.each do |p|
-          case p.downcase
+        [ssl_version].flatten.each do |p|
+          case p.to_s.downcase
           when 'sslv2'
             protocols_bitmask |= EventMachine::EM_PROTO_SSLv2
           when 'sslv3'
             protocols_bitmask |= EventMachine::EM_PROTO_SSLv3
           when 'tlsv1'
             protocols_bitmask |= EventMachine::EM_PROTO_TLSv1
-          when 'tlsv1.1'
+          when 'tlsv1_1'
             protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_1
-          when 'tlsv1.2'
+          when 'tlsv1_2'
             protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_2
           else
             raise("Unrecognized SSL/TLS Protocol: #{p}")

--- a/tests/test_ssl_extensions.rb
+++ b/tests/test_ssl_extensions.rb
@@ -17,7 +17,7 @@ if EM.ssl?
       end
 
       def connection_completed
-        start_tls(:protocols => %w(tlsv1), :sni_hostname => 'example.com')
+        start_tls(:ssl_version => :tlsv1, :sni_hostname => 'example.com')
       end
     end
 
@@ -28,7 +28,7 @@ if EM.ssl?
       end
 
       def post_init
-        start_tls(:protocols => %w(TLSv1))
+        start_tls(:ssl_version => :TLSv1)
       end
     end
 

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -26,7 +26,7 @@ if EM.ssl?
     module ClientAny
       include Client
       def connection_completed
-        start_tls(:protocols => %w(sslv2 sslv3 tlsv1 tlsv1.1 tlsv1.2))
+        start_tls(:ssl_version => %w(sslv2 sslv3 tlsv1 tlsv1_1 tlsv1_2))
       end
     end
 
@@ -40,28 +40,28 @@ if EM.ssl?
     module ClientSSLv3
       include Client
       def connection_completed
-        start_tls(:protocols => %w(SSLv3))
+        start_tls(:ssl_version => %w(SSLv3))
       end
     end
 
     module ServerSSLv3
       include Server
       def post_init
-        start_tls(:protocols => %w(SSLv3))
+        start_tls(:ssl_version => %w(SSLv3))
       end
     end
 
     module ServerTLSv1CaseInsensitive
       include Server
       def post_init
-        start_tls(:protocols => %w(tlsv1))
+        start_tls(:ssl_version => %w(tlsv1))
       end
     end
 
     module ServerAny
       include Server
       def post_init
-        start_tls(:protocols => %w(sslv2 sslv3 tlsv1 tlsv1.1 tlsv1.2))
+        start_tls(:ssl_version => %w(sslv2 sslv3 tlsv1 tlsv1_1 tlsv1_2))
       end
     end
 
@@ -75,12 +75,12 @@ if EM.ssl?
     module InvalidProtocol
       include Client
       def post_init
-        start_tls(:protocols => %w(tlsv1 badinput))
+        start_tls(:ssl_version => %w(tlsv1 badinput))
       end
     end
 
-    def test_invalid_protocol
-      assert_raises(RuntimeError, "Unrecognized SSL/TLS Protocol: badinput") do
+    def test_invalid_ssl_version
+      assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do
         EM.run do
           EM.start_server("127.0.0.1", 16784, InvalidProtocol)
           EM.connect("127.0.0.1", 16784, InvalidProtocol)
@@ -156,7 +156,7 @@ if EM.ssl?
 
     module ServerV3StopAfterHandshake
       def post_init
-        start_tls(:protocols => %w(SSLv3))
+        start_tls(:ssl_version => %w(SSLv3))
       end
 
       def ssl_handshake_completed
@@ -167,7 +167,7 @@ if EM.ssl?
 
     module ServerTLSv1StopAfterHandshake
       def post_init
-        start_tls(:protocols => %w(TLSv1))
+        start_tls(:ssl_version => %w(TLSv1))
       end
 
       def ssl_handshake_completed


### PR DESCRIPTION
Both Ruby OpenSSL and EventMachine-LE use ssl_version, so we should too.

And protocols sounds too much like NPN / ALPN which are TLS extensions required for SPDY and HTTP/2.0.