### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -878,6 +878,9 @@ void ConnectionDescriptor::_DispatchInboundData (const char *buffer, unsigned lo
 
 		// If our SSL handshake had a problem, shut down the connection.
 		if (s == -2) {
+			#ifndef EPROTO // OpenBSD does not have EPROTO
+			#define EPROTO EINTR
+			#endif
 			#ifdef OS_UNIX
 			UnbindReasonCode = EPROTO;
 			#endif


### PR DESCRIPTION
If EPROTO does not exist define it as EINTR

OpenBSD does not have EPROTO: https://sourceforge.net/p/sshguard/mailman/message/21247557/

Works, tried on 1.2.dev.2 and 1.0.9.1.