### PR TITLE
Close socket on close_connection even after close_connection_after_writing

### DIFF
--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -235,8 +235,14 @@ EventableDescriptor::ScheduleClose
 
 void EventableDescriptor::ScheduleClose (bool after_writing)
 {
-	if (IsCloseScheduled())
+	if (IsCloseScheduled()) {
+		if (!after_writing) {
+			// If closing has become more urgent, then upgrade the scheduled
+			// after_writing close to one NOW.
+			bCloseNow = true;
+		}
 		return;
+	}
 	MyEventMachine->NumCloseScheduled++;
 	// KEEP THIS SYNCHRONIZED WITH ::IsCloseScheduled.
 	if (after_writing)


### PR DESCRIPTION
Previously, calls to close now were ignored if a close was scheduled for after we finish writing. This was problematic in any case where a graceful close was scheduled, but the send buffer might never be consumed, for example:
 - stuck TCP connections
 - extremely slow readers