### PR TITLE
Add regular expression (regex) support to LineText2 protocol's delimiter

### DIFF
--- a/tests/test_ltp2.rb
+++ b/tests/test_ltp2.rb
@@ -72,6 +72,30 @@ class TestLineText2 < Test::Unit::TestCase
     assert_equal( ["Linea", "Lineb", "Linec", "Lined"], a.lines )
   end
 
+  class RegexDelimiter
+    include EM::Protocols::LineText2
+    attr_reader :lines
+    def initialize *args
+      super
+      @delim = /[A-D]/
+      set_delimiter @delim
+    end
+    def receive_line line
+      (@lines ||= []) << line
+    end
+  end
+
+  def test_regex_delimiter
+    testdata = %Q(LineaALinebBLinecCLinedD)
+
+    a = RegexDelimiter.new
+    a.receive_data testdata
+    assert_equal( ["Linea", "Lineb", "Linec", "Lined"], a.lines )
+
+    a = RegexDelimiter.new
+    testdata.length.times {|i| a.receive_data( testdata[i...i+1] ) }
+    assert_equal( ["Linea", "Lineb", "Linec", "Lined"], a.lines )
+  end
 
   #--
   # Test two lines followed by an empty line, ten bytes of binary data, then


### PR DESCRIPTION
This mod allows the use of a regular expression as the end-of-line delimiter in the LineText2 protocol.  The set_delimiter method will accept a regular expression and set the end-of-line delimiter appropriately.  Anything passed to the set_delimiter method other than a regular expression will be converted to a string.  A new test to capture the use of a regular express was added.