### PR TITLE
Pure Ruby EM fixes

### DIFF
--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -92,14 +92,10 @@ module EventMachine
       selectable.send_data data
     end
 
-
-    # The extension version does NOT raise any kind of an error if an attempt is made
-    # to close a non-existent connection. Not sure whether we should. For now, we'll
-    # raise an error here in that case.
     # @private
     def close_connection target, after_writing
-      selectable = Reactor.instance.get_selectable( target ) or raise "unknown close_connection target"
-      selectable.schedule_close after_writing
+      selectable = Reactor.instance.get_selectable( target )
+      selectable.schedule_close after_writing if selectable
     end
 
     # @private

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -499,6 +499,14 @@ module EventMachine
 
     def heartbeat
     end
+
+    def schedule_close(after_writing=false)
+      if after_writing
+        @close_requested = true
+      else
+        @close_scheduled = true
+      end
+    end
   end
 
 end
@@ -604,16 +612,6 @@ module EventMachine
       # TODO, coalesce here perhaps by being smarter about appending to @outbound_q.last?
       unless @close_scheduled or @close_requested or !data or data.length <= 0
         @outbound_q << data.to_s
-      end
-    end
-
-    # #schedule_close
-    # The application wants to close the connection.
-    def schedule_close after_writing
-      if after_writing
-        @close_requested = true
-      else
-        @close_scheduled = true
       end
     end
 
@@ -1005,18 +1003,14 @@ module EventMachine
         @close_scheduled = true
         EventMachine::event_callback uuid, ConnectionUnbound, nil
       end
-
     end
-
 
     def send_data data
       send_datagram data, @return_address
     end
-
   end
 end
 
 # load base EM api on top, now that we have the underlying pure ruby
 # implementation defined
 require 'eventmachine'
-

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -223,6 +223,12 @@ module EventMachine
       r = Reactor.instance.get_selectable( sig ) or raise "unknown set_comm_inactivity_timeout target"
       r.set_inactivity_timeout tm
     end
+
+    # @private
+    def set_pending_connect_timeout sig, tm
+      # Needs to be implemented. Currently a no-op stub to allow
+      # certain software to operate with the EM pure-ruby.
+    end
   end
 end
 


### PR DESCRIPTION
This pull request:

- Moves `schedule_close()` to `Selectable` (fixing EM socket `close()`)
- No-op stubs `set_pending_connect_timeout()` to allow some software/libraries to work with the pure Ruby EM reactor until it is properly implemented
- Fixed `close_connection()` to allow closing a nonexistent connection (matching C reactor)