### PR TITLE
fixes compilation on latest ubuntu

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -206,6 +206,7 @@ when /darwin/
 
 when /linux/
   add_define 'HAVE_EPOLL' if have_func('epoll_create', 'sys/epoll.h')
+  check_libs(%w[stdc++], true)
 
   # on Unix we need a g++ link, not gcc.
   CONFIG['LDSHARED'] = "$(CXX) -shared"


### PR DESCRIPTION
I am not sure why but I need this for the shared library to be properly linked to libstdc++ on ubuntu 15.10.