### PR TITLE
Fix incorrect tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ or add this to your Gemfile if you use [Bundler](http://gembundler.com/):
 For an introduction to EventMachine, check out:
 
  * [blog post about EventMachine by Ilya Grigorik](http://www.igvita.com/2008/05/27/ruby-eventmachine-the-speed-demon/).
- * [EventMachine Introductions by Dan Sinclair](http://everburning.com/news/eventmachine-introductions/).
+ * [EventMachine Introductions by Dan Sinclair](http://everburning.com/news/eventmachine-introductions.html).
 
 
 ### Server example: Echo server ###


### PR DESCRIPTION
The old link redirects to `http://everburning.com/news/eventmachine-introductions/.html`