### PR TITLE
Fix deregistering descriptor when using KQUEUE

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1889,6 +1889,14 @@ void EventMachine_t::Deregister (EventableDescriptor *ed)
 		ModifiedDescriptors.erase(ed);
 	}
 	#endif
+
+	#ifdef HAVE_KQUEUE
+	if (Poller == Poller_Kqueue) {
+		assert (ed->GetSocket() != INVALID_SOCKET);
+
+		ModifiedDescriptors.erase(ed);
+	}
+	#endif
 }
 
 


### PR DESCRIPTION
It was possible that a write was planned to happen but the socket got closed
in the meantime. This would lead to a serious error as it would then attempt
to write on closed socket (-1 socket) and crash.

To be more specific, the error I got at the application was:
```
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: arm kqueue writer failed on -1: Bad file descriptor
```

It's not clear to me where and how to write a spec for this (this only manifests on a KQUEUE system), please let me know how to proceed.