### PR TITLE
Fix deregistering descriptor when using KQUEUE

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1889,6 +1889,14 @@ void EventMachine_t::Deregister (EventableDescriptor *ed)
 		ModifiedDescriptors.erase(ed);
 	}
 	#endif
+
+	#ifdef HAVE_KQUEUE
+	if (Poller == Poller_Kqueue) {
+		assert (ed->GetSocket() != INVALID_SOCKET);
+
+		ModifiedDescriptors.erase(ed);
+	}
+	#endif
 }
 
 


### PR DESCRIPTION
It was possible that a write was planned to happen but the socket got closed
in the meantime. This would like to a serious error as it would then attempt
to write on closed socket (-1 socket) and crash.