### PR TITLE
Use Acceptors to get peer and sock names if not present in Connections

### DIFF
--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -12,12 +12,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files README.md CHANGELOG.md GNU LICENSE rakelib ext java lib docs`.split
   s.test_files = `git ls-files tests examples`.split
 
-  if RUBY_PLATFORM =~ /java/
-    s.files << "lib/rubyeventmachine.jar"
-    s.platform = 'java'
-  else
-    s.extensions = ["ext/extconf.rb", "ext/fastfilereader/extconf.rb"]
-  end
+  s.extensions = ["ext/extconf.rb", "ext/fastfilereader/extconf.rb"]
 
   s.add_development_dependency 'test-unit', '~> 2.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9.5'

--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -12,7 +12,12 @@ Gem::Specification.new do |s|
   s.files = `git ls-files README.md CHANGELOG.md GNU LICENSE rakelib ext java lib docs`.split
   s.test_files = `git ls-files tests examples`.split
 
-  s.extensions = ["ext/extconf.rb", "ext/fastfilereader/extconf.rb"]
+  if RUBY_PLATFORM =~ /java/
+    s.files << "lib/rubyeventmachine.jar"
+    s.platform = 'java'
+  else
+    s.extensions = ["ext/extconf.rb", "ext/fastfilereader/extconf.rb"]
+  end
 
   s.add_development_dependency 'test-unit', '~> 2.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9.5'

--- a/java/src/com/rubyeventmachine/EmReactor.java
+++ b/java/src/com/rubyeventmachine/EmReactor.java
@@ -521,11 +521,27 @@ public class EmReactor {
 	}
 
 	public Object[] getPeerName (long sig) {
-		return Connections.get(sig).getPeerName();
+	    EventableChannel channel = Connections.get(sig);
+	    if (channel != null) {
+	        return Connections.get(sig).getPeerName();
+	    }
+	    else { 
+	        ServerSocketChannel acceptor = Acceptors.get(sig);
+	        return  new Object[] { acceptor.socket().getLocalPort(),
+	                acceptor.socket().getInetAddress().getHostAddress() };   
+	    }
 	}
 
 	public Object[] getSockName (long sig) {
-		return Connections.get(sig).getSockName();
+    	EventableChannel channel = Connections.get(sig);
+    	if (channel != null) {
+    	    return Connections.get(sig).getSockName();
+    	}
+    	else {
+    	    ServerSocketChannel acceptor = Acceptors.get(sig);
+    	    return new Object[] { acceptor.socket().getLocalPort(),
+    	            acceptor.socket().getInetAddress().getHostAddress() };
+    	}
 	}
 
 	public long attachChannel (SocketChannel sc, boolean watch_mode) {

--- a/lib/jeventmachine.rb
+++ b/lib/jeventmachine.rb
@@ -77,6 +77,8 @@ module EventMachine
   ConnectionNotifyWritable = 107
   # @private
   SslHandshakeCompleted = 108
+  # @private
+  SslVerify = 109
 
   # Exceptions that are defined in rubymain.cpp
   class ConnectionError < RuntimeError; end


### PR DESCRIPTION
On Jruby, when starting a tcp server locally using the 0 port argument (to select a random port), I was later trying to discover what port it was on by calling: `Socket.unpack_sockaddr_in( EM.get_sockname( signature ) ).first`

Because the server doesn't get added to the Connections HashMap, I was getting an NPE. This PR appears to address it in my local tests, and it favors entries in Connections and falls back to the Acceptors.

I also added a couple things to make java builds friendlier, and a missing constant that was also causing me some pains.

Things appear to install and run fine, but when I try to run tests (using JRuby 9.1.2.0), I end up getting many errors about too many files being open. I could crank up my ulimit (it's already at 512), but I'm not sure how much further I need to go.