### PR TITLE
Raise a ruby exception for InvalidWatchSignature

### DIFF
--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -58,7 +58,7 @@ static VALUE EM_eConnectionError;
 static VALUE EM_eUnknownTimerFired;
 static VALUE EM_eConnectionNotBound;
 static VALUE EM_eUnsupported;
-static VALUE EM_eInvalidWatchSignature;
+static VALUE EM_eInvalidSignature;
 
 static VALUE Intern_at_signature;
 static VALUE Intern_at_timers;
@@ -1040,7 +1040,7 @@ static VALUE t_unwatch_filename (VALUE self UNUSED, VALUE sig)
 	try {
 		evma_unwatch_filename(NUM2BSIG (sig));
 	} catch (std::runtime_error e) {
-		rb_raise (EM_eInvalidWatchSignature, "%s", e.what());
+		rb_raise (EM_eInvalidSignature, "%s", e.what());
 	}
 	
 	return Qnil;
@@ -1395,7 +1395,7 @@ extern "C" void Init_rubyeventmachine()
 	EM_eConnectionNotBound = rb_define_class_under (EmModule, "ConnectionNotBound", rb_eRuntimeError);
 	EM_eUnknownTimerFired = rb_define_class_under (EmModule, "UnknownTimerFired", rb_eRuntimeError);
 	EM_eUnsupported = rb_define_class_under (EmModule, "Unsupported", rb_eRuntimeError);
-	EM_eInvalidWatchSignature = rb_define_class_under (EmModule, "InvalidWatchSignature", rb_eRuntimeError);
+	EM_eInvalidSignature = rb_define_class_under (EmModule, "InvalidSignature", rb_eRuntimeError);
 
 	rb_define_module_function (EmModule, "initialize_event_machine", (VALUE(*)(...))t_initialize_event_machine, 0);
 	rb_define_module_function (EmModule, "run_machine_once", (VALUE(*)(...))t_run_machine_once, 0);

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -58,6 +58,7 @@ static VALUE EM_eConnectionError;
 static VALUE EM_eUnknownTimerFired;
 static VALUE EM_eConnectionNotBound;
 static VALUE EM_eUnsupported;
+static VALUE EM_eInvalidWatchSignature;
 
 static VALUE Intern_at_signature;
 static VALUE Intern_at_timers;
@@ -1036,7 +1037,12 @@ t_unwatch_filename
 
 static VALUE t_unwatch_filename (VALUE self UNUSED, VALUE sig)
 {
-	evma_unwatch_filename(NUM2BSIG (sig));
+	try {
+		evma_unwatch_filename(NUM2BSIG (sig));
+	} catch (std::runtime_error e) {
+		rb_raise (EM_eInvalidWatchSignature, "%s", e.what());
+	}
+	
 	return Qnil;
 }
 
@@ -1389,6 +1395,7 @@ extern "C" void Init_rubyeventmachine()
 	EM_eConnectionNotBound = rb_define_class_under (EmModule, "ConnectionNotBound", rb_eRuntimeError);
 	EM_eUnknownTimerFired = rb_define_class_under (EmModule, "UnknownTimerFired", rb_eRuntimeError);
 	EM_eUnsupported = rb_define_class_under (EmModule, "Unsupported", rb_eRuntimeError);
+	EM_eInvalidWatchSignature = rb_define_class_under (EmModule, "InvalidWatchSignature", rb_eRuntimeError);
 
 	rb_define_module_function (EmModule, "initialize_event_machine", (VALUE(*)(...))t_initialize_event_machine, 0);
 	rb_define_module_function (EmModule, "run_machine_once", (VALUE(*)(...))t_run_machine_once, 0);

--- a/tests/test_file_watch.rb
+++ b/tests/test_file_watch.rb
@@ -58,7 +58,10 @@ class TestFileWatch < Test::Unit::TestCase
 
     # Refer: https://github.com/eventmachine/eventmachine/issues/512
     def test_invalid_signature
-      EventMachine.run {
+      # This works fine with kqueue, only fails with linux inotify.
+      omit_if(EM.kqueue?)
+
+      EM.run {
         file = Tempfile.new('foo')
 
         w1 = EventMachine.watch_file(file.path)
@@ -67,6 +70,8 @@ class TestFileWatch < Test::Unit::TestCase
         assert_raise EventMachine::InvalidSignature do
           w2.stop_watching
         end
+
+        EM.stop
       }
     end
   else

--- a/tests/test_file_watch.rb
+++ b/tests/test_file_watch.rb
@@ -55,6 +55,20 @@ class TestFileWatch < Test::Unit::TestCase
       assert($deleted)
       assert($unbind)
     end
+
+    # Refer: https://github.com/eventmachine/eventmachine/issues/512
+    def test_invalid_signature
+      EventMachine.run {
+        file = Tempfile.new('foo')
+
+        w1 = EventMachine.watch_file(file.path)
+        w2 = EventMachine.watch_file(file.path)
+
+        assert_raise EventMachine::InvalidSignature do
+          w2.stop_watching
+        end
+      }
+    end
   else
     warn "EM.watch_file not implemented, skipping tests in #{__FILE__}"
 


### PR DESCRIPTION
Addresses #512

Some how the runtime error thrown in evma_unwatch_filename was not caught and EM crashed with std::runtime_error. A Simple patch to fix this by throwing a ruby exception instead.

Not sure if this is the correct fix but at least the ruby exception can be caught and handled further. 