### PR TITLE
Fix segfault when an Exception is raised from unbind callback

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -164,6 +164,8 @@ EventMachine_t::~EventMachine_t()
 {
 	// Run down descriptors
 	size_t i;
+	for (i = 0; i < DescriptorsToDelete.size(); i++)
+ 		delete DescriptorsToDelete[i];
 	for (i = 0; i < NewDescriptors.size(); i++)
 		delete NewDescriptors[i];
 	for (i = 0; i < Descriptors.size(); i++)

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -840,6 +840,17 @@ void EventMachine_t::_CleanupSockets()
 		EventableDescriptor *ed = Descriptors[i];
 		assert (ed);
 		if (ed->ShouldDelete()) {
+			DescriptorsToDelete.push_back(ed);
+		}
+		else
+			Descriptors [j++] = ed;
+	}
+	while ((size_t)j < Descriptors.size())
+		Descriptors.pop_back();
+
+	nSockets = DescriptorsToDelete.size();
+	for (i=0; i < nSockets; i++) {
+		EventableDescriptor *ed = DescriptorsToDelete[i];
 		#ifdef HAVE_EPOLL
 			if (Poller == Poller_Epoll) {
 				assert (epfd != -1);
@@ -855,13 +866,9 @@ void EventMachine_t::_CleanupSockets()
 				ModifiedDescriptors.erase(ed);
 			}
 		#endif
-			delete ed;
-		}
-		else
-			Descriptors [j++] = ed;
+		delete ed;
 	}
-	while ((size_t)j < Descriptors.size())
-		Descriptors.pop_back();
+	DescriptorsToDelete.clear();
 }
 
 /*********************************

--- a/ext/em.h
+++ b/ext/em.h
@@ -242,6 +242,7 @@ class EventMachine_t
 		map<int, Bindable_t*> Pids;
 		vector<EventableDescriptor*> Descriptors;
 		vector<EventableDescriptor*> NewDescriptors;
+		vector<EventableDescriptor*> DescriptorsToDelete;
 		set<EventableDescriptor*> ModifiedDescriptors;
 
 		SOCKET LoopBreakerReader;

--- a/tests/test_exc.rb
+++ b/tests/test_exc.rb
@@ -1,6 +1,13 @@
 require 'em_test_helper'
 
 class TestSomeExceptions < Test::Unit::TestCase
+  class DoomedConnectionError < StandardError
+  end
+  class DoomedConnection < EventMachine::Connection
+    def unbind
+      raise DoomedConnectionError
+    end
+  end
 
   # Read the commentary in EM#run.
   # This test exercises the ensure block in #run that makes sure
@@ -21,6 +28,14 @@ class TestSomeExceptions < Test::Unit::TestCase
     assert_raises(RuntimeError) {
       EM.run {
       raise "some exception"
+    }
+    }
+  end
+
+  def test_exception_on_unbind
+    assert_raises(DoomedConnectionError) {
+      EM.run {
+      EM.connect("localhost", 8888, DoomedConnection)
     }
     }
   end


### PR DESCRIPTION
I experienced a segfault similar to #765, #758 and #761, debugging the code I found that the problem was caused by a double free of the a `EventableDescriptor`.

In detail `EventMachine_t::_CleanupSockets()` was calling the `EventableDescriptor` destructor that triggers the `Connection#unbind` callback. The problem is that when the callback raises an exception, it stops the EventMachine and eventually calls the `EventMachine_t` destructor that attempts to destroy the same `EventableDescriptor` since the `EventMachine_t::_CleanupSockets()` function hasn't yet cleaned up the Descriptors vector.
The workaround used was very crude but it works, it delays the destruction of the `EventableDescriptor` to after they are removed from the `Descriptors` vector.