### PR TITLE
Allow destructors to throw when compiling in >= C++11

### DIFF
--- a/ext/binder.cpp
+++ b/ext/binder.cpp
@@ -116,10 +116,7 @@ Bindable_t::Bindable_t()
 Bindable_t::~Bindable_t
 ***********************/
 
-Bindable_t::~Bindable_t()
-#if __cplusplus >= 201103L
-noexcept(false)
-#endif
+Bindable_t::~Bindable_t() NO_EXCEPT_FALSE
 {
 	BindingBag.erase (Binding);
 }

--- a/ext/binder.cpp
+++ b/ext/binder.cpp
@@ -117,6 +117,9 @@ Bindable_t::~Bindable_t
 ***********************/
 
 Bindable_t::~Bindable_t()
+#if __cplusplus >= 201103L
+noexcept(false)
+#endif
 {
 	BindingBag.erase (Binding);
 }

--- a/ext/binder.h
+++ b/ext/binder.h
@@ -30,7 +30,11 @@ class Bindable_t
 
 	public:
 		Bindable_t();
+#if __cplusplus < 201103L
 		virtual ~Bindable_t();
+#else
+		virtual ~Bindable_t() noexcept(false);
+#endif
 
 		const uintptr_t GetBinding() {return Binding;}
 

--- a/ext/binder.h
+++ b/ext/binder.h
@@ -21,6 +21,12 @@ See the file COPYING for complete licensing information.
 #define __ObjectBindings__H_
 
 
+#if __cplusplus >= 201103L
+#define NO_EXCEPT_FALSE noexcept(false)
+#else
+#define NO_EXCEPT_FALSE
+#endif
+
 class Bindable_t
 {
 	public:
@@ -30,11 +36,7 @@ class Bindable_t
 
 	public:
 		Bindable_t();
-#if __cplusplus < 201103L
-		virtual ~Bindable_t();
-#else
-		virtual ~Bindable_t() noexcept(false);
-#endif
+		virtual ~Bindable_t() NO_EXCEPT_FALSE;
 
 		const uintptr_t GetBinding() {return Binding;}
 

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -127,6 +127,9 @@ EventableDescriptor::~EventableDescriptor
 *****************************************/
 
 EventableDescriptor::~EventableDescriptor()
+#if __cplusplus >= 201103L
+noexcept(false)
+#endif
 {
 	if (NextHeartbeat)
 		MyEventMachine->ClearHeartbeat(NextHeartbeat, this);

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -126,10 +126,7 @@ EventableDescriptor::EventableDescriptor (SOCKET sd, EventMachine_t *em):
 EventableDescriptor::~EventableDescriptor
 *****************************************/
 
-EventableDescriptor::~EventableDescriptor()
-#if __cplusplus >= 201103L
-noexcept(false)
-#endif
+EventableDescriptor::~EventableDescriptor() NO_EXCEPT_FALSE
 {
 	if (NextHeartbeat)
 		MyEventMachine->ClearHeartbeat(NextHeartbeat, this);

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -37,7 +37,11 @@ class EventableDescriptor: public Bindable_t
 {
 	public:
 		EventableDescriptor (SOCKET, EventMachine_t*);
+#if __cplusplus < 201103L
 		virtual ~EventableDescriptor();
+#else
+		virtual ~EventableDescriptor() noexcept(false);
+#endif
 
 		SOCKET GetSocket() {return MySocket;}
 		void SetSocketInvalid() { MySocket = INVALID_SOCKET; }
@@ -365,7 +369,11 @@ class PipeDescriptor: public EventableDescriptor
 {
 	public:
 		PipeDescriptor (SOCKET, pid_t, EventMachine_t*);
+#if __cplusplus < 201103L
 		virtual ~PipeDescriptor();
+#else
+		virtual ~PipeDescriptor() noexcept(false);
+#endif
 
 		virtual void Read();
 		virtual void Write();

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -37,11 +37,7 @@ class EventableDescriptor: public Bindable_t
 {
 	public:
 		EventableDescriptor (SOCKET, EventMachine_t*);
-#if __cplusplus < 201103L
-		virtual ~EventableDescriptor();
-#else
-		virtual ~EventableDescriptor() noexcept(false);
-#endif
+		virtual ~EventableDescriptor() NO_EXCEPT_FALSE;
 
 		SOCKET GetSocket() {return MySocket;}
 		void SetSocketInvalid() { MySocket = INVALID_SOCKET; }
@@ -369,11 +365,7 @@ class PipeDescriptor: public EventableDescriptor
 {
 	public:
 		PipeDescriptor (SOCKET, pid_t, EventMachine_t*);
-#if __cplusplus < 201103L
-		virtual ~PipeDescriptor();
-#else
-		virtual ~PipeDescriptor() noexcept(false);
-#endif
+		virtual ~PipeDescriptor() NO_EXCEPT_FALSE;
 
 		virtual void Read();
 		virtual void Write();

--- a/ext/pipe.cpp
+++ b/ext/pipe.cpp
@@ -46,10 +46,7 @@ PipeDescriptor::PipeDescriptor (int fd, pid_t subpid, EventMachine_t *parent_em)
 PipeDescriptor::~PipeDescriptor
 *******************************/
 
-PipeDescriptor::~PipeDescriptor()
-#if __cplusplus >= 201103L
-noexcept(false)
-#endif
+PipeDescriptor::~PipeDescriptor() NO_EXCEPT_FALSE
 {
 	// Run down any stranded outbound data.
 	for (size_t i=0; i < OutboundPages.size(); i++)

--- a/ext/pipe.cpp
+++ b/ext/pipe.cpp
@@ -47,6 +47,9 @@ PipeDescriptor::~PipeDescriptor
 *******************************/
 
 PipeDescriptor::~PipeDescriptor()
+#if __cplusplus >= 201103L
+noexcept(false)
+#endif
 {
 	// Run down any stranded outbound data.
 	for (size_t i=0; i < OutboundPages.size(); i++)


### PR DESCRIPTION
In C++11 and later, destructors are marked `noexcept(true)` by default.  All throws become calls to `terminate()`.  To enable the original intent of the throw, such destructors (and if virtual, those of its parent classes) need to be explicitly marked `noexcept(false)` when compiled in a dialect >= C++11.