### PR TITLE
Wrap all callbacks with rb_rescue to prevent Ruby exceptions to disturb C++ land

### DIFF
--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -52,11 +52,15 @@ module EventMachine
         # associate_callback_target sig
 
         # Call a superclass's #initialize if it has one
-        initialize(*args)
+        begin
+          initialize(*args)
 
-        # post initialize callback
-        post_init
-
+          # post initialize callback
+          post_init
+        rescue Exception => ex
+          EventMachine::close_connection @signature, false
+          raise ex
+        end
         self
       end
     end

--- a/tests/test_exc.rb
+++ b/tests/test_exc.rb
@@ -1,6 +1,13 @@
 require 'em_test_helper'
 
 class TestSomeExceptions < Test::Unit::TestCase
+  class DoomedConnectionError < StandardError
+  end
+  class DoomedConnection < EventMachine::Connection
+    def unbind
+      raise DoomedConnectionError
+    end
+  end
 
   # Read the commentary in EM#run.
   # This test exercises the ensure block in #run that makes sure
@@ -25,4 +32,11 @@ class TestSomeExceptions < Test::Unit::TestCase
     }
   end
 
+  def test_exception_on_unbind
+    assert_raises(DoomedConnectionError) {
+      EM.run {
+      EM.connect("localhost", 8888, DoomedConnection)
+    }
+    }
+  end
 end

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -80,7 +80,7 @@ if EM.ssl?
     end
 
     def test_invalid_ssl_version
-      assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do
+      assert_raises(EventMachine::MultipleExceptions, "Unrecognized SSL/TLS Protocol: badinput") do
         EM.run do
           EM.start_server("127.0.0.1", 16784, InvalidProtocol)
           EM.connect("127.0.0.1", 16784, InvalidProtocol)


### PR DESCRIPTION
Alternative to #766 and #768.