### PR TITLE
Require 'em_test_helper'

### DIFF
--- a/tests/test_threaded_resource.rb
+++ b/tests/test_threaded_resource.rb
@@ -1,3 +1,5 @@
+require 'em_test_helper'
+
 class TestThreadedResource < Test::Unit::TestCase
   def object
     @object ||= {}


### PR DESCRIPTION
Fixes:

~~~
$ ruby -Itests tests/test_threaded_resource.rb 
tests/test_threaded_resource.rb:1:in `<main>': uninitialized constant Test (NameError)
~~~