### PR TITLE
Allow for larger values in oneshot timer intervals

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1151,7 +1151,7 @@ void EventMachine_t::_RunTimers()
 EventMachine_t::InstallOneshotTimer
 ***********************************/
 
-const uintptr_t EventMachine_t::InstallOneshotTimer (int milliseconds)
+const uintptr_t EventMachine_t::InstallOneshotTimer (uint64_t milliseconds)
 {
 	if (Timers.size() > MaxOutstandingTimers)
 		return false;

--- a/ext/em.h
+++ b/ext/em.h
@@ -142,7 +142,7 @@ class EventMachine_t
 		void ScheduleHalt();
 		bool Stopping();
 		void SignalLoopBreaker();
-		const uintptr_t InstallOneshotTimer (int);
+		const uintptr_t InstallOneshotTimer (uint64_t);
 		const uintptr_t ConnectToServer (const char *, int, const char *, int);
 		const uintptr_t ConnectToUnixServer (const char *);
 

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -262,7 +262,7 @@ t_add_oneshot_timer
 
 static VALUE t_add_oneshot_timer (VALUE self UNUSED, VALUE interval)
 {
-	const uintptr_t f = evma_install_oneshot_timer (FIX2INT (interval));
+	const uintptr_t f = evma_install_oneshot_timer (FIX2LONG (interval));
 	if (!f)
 		rb_raise (rb_eRuntimeError, "%s", "ran out of timers; use #set_max_timers to increase limit");
 	return BSIG2NUM (f);

--- a/java/src/com/rubyeventmachine/EmReactor.java
+++ b/java/src/com/rubyeventmachine/EmReactor.java
@@ -373,7 +373,7 @@ public class EmReactor {
 		}
 	}
 
-	public long installOneshotTimer (int milliseconds) {
+	public long installOneshotTimer (BigInteger milliseconds) {
 		long s = createBinding();
 		long deadline = new Date().getTime() + milliseconds;
 

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -324,7 +324,7 @@ module EventMachine
     code = args.shift || block
     if code
       # check too many timers!
-      s = add_oneshot_timer((interval.to_f * 1000).to_i)
+      s = add_oneshot_timer(interval.to_i * 1000)
       @timers[s] = code
       s
     end

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -324,7 +324,7 @@ module EventMachine
     code = args.shift || block
     if code
       # check too many timers!
-      s = add_oneshot_timer(interval.to_i * 1000)
+      s = add_oneshot_timer((interval.to_f * 1000).to_i)
       @timers[s] = code
       s
     end

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -93,6 +93,13 @@ class TestTimers < Test::Unit::TestCase
     assert_equal 4, x
   end
 
+  def test_oneshot_timer_large_future_value
+    large_value = 11948602000
+    EM.run {
+      EM.add_timer(large_value) { EM.stop }
+      EM.add_timer(0.02) { EM.stop }
+    }
+  end
 
   # This test is only applicable to compiled versions of the reactor.
   # Pure ruby and java versions have no built-in limit on the number of outstanding timers.


### PR DESCRIPTION
In the Sensu project we've added support for scheduling timers using cron syntax. In https://github.com/sensu/sensu/issues/1665 a user reported that they were able to cause an exception in scheduling by configuring a timer that should run on the first of every month.

This pull request seeks to address this exception by using variable types which allow for larger interval values.