### PR TITLE
Method report_connection_error_status is missing

### DIFF
--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -430,6 +430,11 @@ module EventMachine
       # Needs to be implemented. Currently a no-op stub to allow
       # certain software to operate with the EM pure-ruby.
     end
+
+    # @private
+    def report_connection_error_status signature
+      get_sock_opt signature, Socket::SOL_SOCKET, Socket::SO_ERROR
+    end
   end
 end
 

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -433,7 +433,7 @@ module EventMachine
 
     # @private
     def report_connection_error_status signature
-      get_sock_opt signature, Socket::SOL_SOCKET, Socket::SO_ERROR
+      get_sock_opt(signature, Socket::SOL_SOCKET, Socket::SO_ERROR).int
     end
   end
 end


### PR DESCRIPTION
In ```Connection::error?``` the method ```EventMachine::report_connection_error_status``` is invoked, which does not exist in the pure ruby version, but does exist in the native C++ version.  This PR provides the equivalent pure ruby version of ```EventMachine::report_connection_error_status```