### PR TITLE
ssl: c++: be verbose about SSL connection errors

### DIFF
--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -345,8 +345,11 @@ SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &cer
 		SSL_set_verify(pSSL, mode, ssl_verify_wrapper);
 	}
 
-	if (!bIsServer)
-		SSL_connect (pSSL);
+	if (!bIsServer) {
+		int e = SSL_connect (pSSL);
+		if (e != 1)
+			ERR_print_errors_fp(stderr);
+	}
 }
 
 
@@ -397,6 +400,7 @@ int SslBox_t::GetPlaintext (char *buf, int bufsize)
 		if (e != 1) {
 			int er = SSL_get_error (pSSL, e);
 			if (er != SSL_ERROR_WANT_READ) {
+				ERR_print_errors_fp(stderr);
 				// Return -1 for a nonfatal error, -2 for an error that should force the connection down.
 				return (er == SSL_ERROR_SSL) ? (-2) : (-1);
 			}


### PR DESCRIPTION
This change allows more easy debugging of applications that use eventmachine (native mode) with SSL.
Example of the output:
```
139861096265472:error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol:s23_srvr.c:640:
```
