### PR TITLE
Add gemspec metadata for MinGW builds

### DIFF
--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files tests examples`.split
 
   s.extensions = ["ext/extconf.rb", "ext/fastfilereader/extconf.rb"]
+  s.metadata["msys2_mingw_dependencies"] = "openssl"
 
   s.add_development_dependency 'test-unit', '~> 2.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9.5'


### PR DESCRIPTION
For another example, see [ruby / openssl openssl.gemspec:25](https://github.com/ruby/openssl/blob/5c1c0fa507fc517596041c7bee9aa34172425649/openssl.gemspec#L25).

This allows the RubyInstaller2 runtime files to load the MinGW OpenSSL package before the compile is started.

Also, see <https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers>