### PR TITLE
Fix for old RubyGems

### DIFF
--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -13,7 +13,10 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files tests examples`.split
 
   s.extensions = ["ext/extconf.rb", "ext/fastfilereader/extconf.rb"]
-  s.metadata["msys2_mingw_dependencies"] = "openssl"
+
+  if s.respond_to?(:metadata=)
+    s.metadata = { "msys2_mingw_dependencies" => "openssl" }
+  end
 
   s.add_development_dependency 'test-unit', '~> 2.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9.5'


### PR DESCRIPTION
Fix for https://github.com/eventmachine/eventmachine/commit/208027e3ea808ddf3b297e2578c148017db2a27f.

On Appveyor, all ruby versions have updated RubyGems.  Saw something similar in a recent ruby/ruby commit.