### PR TITLE
Correct EM::Completion doc location [ci skip]

### DIFF
--- a/lib/em/completion.rb
+++ b/lib/em/completion.rb
@@ -1,165 +1,168 @@
-# = EM::Completion
-#
-# A completion is a callback container for various states of completion. In
-# its most basic form it has a start state and a finish state.
-#
-# This implementation includes some hold-back from the EM::Deferrable
-# interface in order to be compatible - but it has a much cleaner
-# implementation.
-#
-# In general it is preferred that this implementation be used as a state
-# callback container than EM::DefaultDeferrable or other classes including
-# EM::Deferrable. This is because it is generally more sane to keep this level
-# of state in a dedicated state-back container. This generally leads to more
-# malleable interfaces and software designs, as well as eradicating nasty bugs
-# that result from abstraction leakage.
-#
-# == Basic Usage
-#
-# As already mentioned, the basic usage of a Completion is simply for its two
-# final states, :succeeded and :failed.
-#
-# An asynchronous operation will complete at some future point in time, and
-# users often want to react to this event. API authors will want to expose
-# some common interface to react to these events.
-#
-# In the following example, the user wants to know when a short lived
-# connection has completed its exchange with the remote server. The simple
-# protocol just waits for an ack to its message.
-#
-#    class Protocol < EM::Connection
-#      include EM::P::LineText2
-#
-#      def initialize(message, completion)
-#        @message, @completion = message, completion
-#        @completion.completion { close_connection }
-#        @completion.timeout(1, :timeout)
-#      end
-#
-#      def post_init
-#        send_data(@message)
-#      end
-#
-#      def receive_line(line)
-#        case line
-#        when /ACK/i
-#          @completion.succeed line
-#        when /ERR/i
-#          @completion.fail :error, line
-#        else
-#          @completion.fail :unknown, line
-#        end
-#      end
-#
-#      def unbind
-#        @completion.fail :disconnected unless @completion.completed?
-#      end
-#    end
-#
-#    class API
-#      attr_reader :host, :port
-#
-#      def initialize(host = 'example.org', port = 8000)
-#        @host, @port = host, port
-#      end
-#
-#      def request(message)
-#        completion = EM::Deferrable::Completion.new
-#        EM.connect(host, port, Protocol, message, completion)
-#        completion
-#      end
-#    end
-#
-#    api = API.new
-#    completion = api.request('stuff')
-#    completion.callback do |line|
-#      puts "API responded with: #{line}"
-#    end
-#    completion.errback do |type, line|
-#      case type
-#      when :error
-#        puts "API error: #{line}"
-#      when :unknown
-#        puts "API returned unknown response: #{line}"
-#      when :disconnected
-#        puts "API server disconnected prematurely"
-#      when :timeout
-#        puts "API server did not respond in a timely fashion"
-#      end
-#    end
-#
-# == Advanced Usage
-#
-# This completion implementation also supports more state callbacks and
-# arbitrary states (unlike the original Deferrable API). This allows for basic
-# stateful process encapsulation. One might use this to setup state callbacks
-# for various states in an exchange like in the basic usage example, except
-# where the applicaiton could be made to react to "connected" and
-# "disconnected" states additionally.
-#
-#    class Protocol < EM::Connection
-#      def initialize(completion)
-#        @response = []
-#        @completion = completion
-#        @completion.stateback(:disconnected) do
-#          @completion.succeed @response.join
-#        end
-#      end
-#
-#      def connection_completed
-#        @host, @port = Socket.unpack_sockaddr_in get_peername
-#        @completion.change_state(:connected, @host, @port)
-#        send_data("GET http://example.org/ HTTP/1.0\r\n\r\n")
-#      end
-#
-#      def receive_data(data)
-#        @response << data
-#      end
-#
-#      def unbind
-#        @completion.change_state(:disconnected, @host, @port)
-#      end
-#    end
-#
-#    completion = EM::Deferrable::Completion.new
-#    completion.stateback(:connected) do |host, port|
-#      puts "Connected to #{host}:#{port}"
-#    end
-#    completion.stateback(:disconnected) do |host, port|
-#      puts "Disconnected from #{host}:#{port}"
-#    end
-#    completion.callback do |response|
-#      puts response
-#    end
-#
-#    EM.connect('example.org', 80, Protocol, completion)
-#
-# == Timeout
-#
-# The Completion also has a timeout. The timeout is global and is not aware of
-# states apart from completion states. The timeout is only engaged if #timeout
-# is called, and it will call fail if it is reached.
-#
-# == Completion states
-#
-# By default there are two completion states, :succeeded and :failed. These
-# states can be modified by subclassing and overrding the #completion_states
-# method. Completion states are special, in that callbacks for all completion
-# states are explcitly cleared when a completion state is entered. This
-# prevents errors that could arise from accidental unterminated timeouts, and
-# other such user errors.
-#
-# == Other notes
-#
-# Several APIs have been carried over from EM::Deferrable for compatibility
-# reasons during a transitionary period. Specifically cancel_errback and
-# cancel_callback are implemented, but their usage is to be strongly
-# discouraged. Due to the already complex nature of reaction systems, dynamic
-# callback deletion only makes the problem much worse. It is always better to
-# add correct conditionals to the callback code, or use more states, than to
-# address such implementaiton issues with conditional callbacks.
-
 module EventMachine
+
+  ##
+  # An EM::Completion instance is a callback container for various states of
+  # completion. In its most basic form it has a start state and a finish state.
+  #
+  # This implementation includes some hold-back from the EM::Deferrable
+  # interface in order to be compatible - but it has a much cleaner
+  # implementation.
+  #
+  # In general it is preferred that this implementation be used as a state
+  # callback container than EM::DefaultDeferrable or other classes including
+  # EM::Deferrable. This is because it is generally more sane to keep this level
+  # of state in a dedicated state-back container. This generally leads to more
+  # malleable interfaces and software designs, as well as eradicating nasty bugs
+  # that result from abstraction leakage.
+  #
+  # == Basic Usage
+  #
+  # As already mentioned, the basic usage of a Completion is simply for its two
+  # final states, :succeeded and :failed.
+  #
+  # An asynchronous operation will complete at some future point in time, and
+  # users often want to react to this event. API authors will want to expose
+  # some common interface to react to these events.
+  #
+  # In the following example, the user wants to know when a short lived
+  # connection has completed its exchange with the remote server. The simple
+  # protocol just waits for an ack to its message.
+  #
+  # ```ruby
+  # class Protocol < EM::Connection
+  #   include EM::P::LineText2
+  # 
+  #   def initialize(message, completion)
+  #     @message, @completion = message, completion
+  #     @completion.completion { close_connection }
+  #     @completion.timeout(1, :timeout)
+  #   end
+  # 
+  #   def post_init
+  #     send_data(@message)
+  #   end
+  # 
+  #   def receive_line(line)
+  #     case line
+  #     when /ACK/i
+  #       @completion.succeed line
+  #     when /ERR/i
+  #       @completion.fail :error, line
+  #     else
+  #       @completion.fail :unknown, line
+  #     end
+  #   end
+  # 
+  #   def unbind
+  #     @completion.fail :disconnected unless @completion.completed?
+  #   end
+  # end
+  # 
+  # class API
+  #   attr_reader :host, :port
+  # 
+  #   def initialize(host = 'example.org', port = 8000)
+  #     @host, @port = host, port
+  #   end
+  # 
+  #   def request(message)
+  #     completion = EM::Deferrable::Completion.new
+  #     EM.connect(host, port, Protocol, message, completion)
+  #     completion
+  #   end
+  # end
+  # 
+  # api = API.new
+  # completion = api.request('stuff')
+  # completion.callback do |line|
+  #   puts "API responded with: #{line}"
+  # end
+  # completion.errback do |type, line|
+  #   case type
+  #   when :error
+  #     puts "API error: #{line}"
+  #   when :unknown
+  #     puts "API returned unknown response: #{line}"
+  #   when :disconnected
+  #     puts "API server disconnected prematurely"
+  #   when :timeout
+  #     puts "API server did not respond in a timely fashion"
+  #   end
+  # end
+  # ```
+  #
+  # == Advanced Usage
+  #
+  # This completion implementation also supports more state callbacks and
+  # arbitrary states (unlike the original Deferrable API). This allows for basic
+  # stateful process encapsulation. One might use this to setup state callbacks
+  # for various states in an exchange like in the basic usage example, except
+  # where the applicaiton could be made to react to "connected" and
+  # "disconnected" states additionally.
+  #
+  # ```ruby
+  # class Protocol < EM::Connection
+  #   def initialize(completion)
+  #     @response = []
+  #     @completion = completion
+  #     @completion.stateback(:disconnected) do
+  #       @completion.succeed @response.join
+  #     end
+  #   end
+  # 
+  #   def connection_completed
+  #     @host, @port = Socket.unpack_sockaddr_in get_peername
+  #     @completion.change_state(:connected, @host, @port)
+  #     send_data("GET http://example.org/ HTTP/1.0\r\n\r\n")
+  #   end
+  # 
+  #   def receive_data(data)
+  #     @response << data
+  #   end
+  # 
+  #   def unbind
+  #     @completion.change_state(:disconnected, @host, @port)
+  #   end
+  # end
+  # 
+  # completion = EM::Deferrable::Completion.new
+  # completion.stateback(:connected) do |host, port|
+  #   puts "Connected to #{host}:#{port}"
+  # end
+  # completion.stateback(:disconnected) do |host, port|
+  #   puts "Disconnected from #{host}:#{port}"
+  # end
+  # completion.callback do |response|
+  #   puts response
+  # end
+  # 
+  # EM.connect('example.org', 80, Protocol, completion)
+  # ```
+  #
+  # == Timeout
+  #
+  # The Completion also has a timeout. The timeout is global and is not aware of
+  # states apart from completion states. The timeout is only engaged if #timeout
+  # is called, and it will call fail if it is reached.
+  #
+  # == Completion states
+  #
+  # By default there are two completion states, :succeeded and :failed. These
+  # states can be modified by subclassing and overrding the #completion_states
+  # method. Completion states are special, in that callbacks for all completion
+  # states are explcitly cleared when a completion state is entered. This
+  # prevents errors that could arise from accidental unterminated timeouts, and
+  # other such user errors.
+  #
+  # == Other notes
+  #
+  # Several APIs have been carried over from EM::Deferrable for compatibility
+  # reasons during a transitionary period. Specifically cancel_errback and
+  # cancel_callback are implemented, but their usage is to be strongly
+  # discouraged. Due to the already complex nature of reaction systems, dynamic
+  # callback deletion only makes the problem much worse. It is always better to
+  # add correct conditionals to the callback code, or use more states, than to
+  # address such implementaiton issues with conditional callbacks.
 
   class Completion
     # This is totally not used (re-implemented), it's here in case people check

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -38,6 +38,7 @@ require 'shellwords'
 require 'thread'
 require 'resolv'
 
+##
 # Top-level EventMachine namespace. If you are looking for EventMachine examples, see {file:docs/GettingStarted.md EventMachine tutorial}.
 #
 # ## Key methods ##
@@ -107,7 +108,7 @@ module EventMachine
   # Once event loop is running, it is perfectly possible to start multiple servers and clients simultaneously: content-aware
   # proxies like [Proxymachine](https://github.com/mojombo/proxymachine) do just that.
   #
-  # ## Using EventMachine with Ruby on Rails and other Web application frameworks ##
+  # ## Using EventMachine with Ruby on Rails and other Web application frameworks
   #
   # Standalone applications often run event loop on the main thread, thus blocking for their entire lifespan. In case of Web applications,
   # if you are running an EventMachine-based app server such as [Thin](http://code.macournoyer.com/thin/) or [Goliath](https://github.com/postrank-labs/goliath/),
@@ -119,16 +120,16 @@ module EventMachine
   # @example Starting EventMachine event loop in the current thread to run the "Hello, world"-like Echo server example
   #
   #   #!/usr/bin/env ruby
-  #
+  #   
   #   require 'rubygems' # or use Bundler.setup
   #   require 'eventmachine'
-  #
+  #   
   #   class EchoServer < EM::Connection
   #     def receive_data(data)
   #       send_data(data)
   #     end
   #   end
-  #
+  #   
   #   EventMachine.run do
   #     EventMachine.start_server("0.0.0.0", 10000, EchoServer)
   #   end
@@ -310,11 +311,11 @@ module EventMachine
   #
   # @example Setting a one-shot timer with EventMachine
   #
-  #  EventMachine.run {
-  #    puts "Starting the run now: #{Time.now}"
-  #    EventMachine.add_timer 5, proc { puts "Executing timer event: #{Time.now}" }
-  #    EventMachine.add_timer(10) { puts "Executing timer event: #{Time.now}" }
-  #  }
+  #   EventMachine.run {
+  #     puts "Starting the run now: #{Time.now}"
+  #     EventMachine.add_timer 5, proc { puts "Executing timer event: #{Time.now}" }
+  #     EventMachine.add_timer(10) { puts "Executing timer event: #{Time.now}" }
+  #   }
   #
   # @param [Integer] delay Delay in seconds
   # @see EventMachine::Timer
@@ -338,9 +339,9 @@ module EventMachine
   #
   # @example Write a dollar-sign to stderr every five seconds, without blocking
   #
-  #  EventMachine.run {
-  #    EventMachine.add_periodic_timer( 5 ) { $stderr.write "$" }
-  #  }
+  #   EventMachine.run {
+  #     EventMachine.add_periodic_timer(5) { $stderr.write "$" }
+  #   }
   #
   # @param [Integer] delay Delay in seconds
   #
@@ -377,40 +378,40 @@ module EventMachine
   #
   # @example Stopping a running EventMachine event loop
   #
-  #  require 'rubygems'
-  #  require 'eventmachine'
+  #   require 'rubygems'
+  #   require 'eventmachine'
+  #   
+  #   module Redmond
+  #     def post_init
+  #       puts "We're sending a dumb HTTP request to the remote peer."
+  #       send_data "GET / HTTP/1.1\r\nHost: www.microsoft.com\r\n\r\n"
+  #     end
+  #   
+  #     def receive_data data
+  #       puts "We received #{data.length} bytes from the remote peer."
+  #       puts "We're going to stop the event loop now."
+  #       EventMachine::stop_event_loop
+  #     end
+  #   
+  #     def unbind
+  #       puts "A connection has terminated."
+  #     end
+  #   end
+  #   
+  #   puts "We're starting the event loop now."
+  #   EventMachine.run {
+  #     EventMachine.connect "www.microsoft.com", 80, Redmond
+  #   }
+  #   puts "The event loop has stopped."
   #
-  #  module Redmond
-  #    def post_init
-  #      puts "We're sending a dumb HTTP request to the remote peer."
-  #      send_data "GET / HTTP/1.1\r\nHost: www.microsoft.com\r\n\r\n"
-  #    end
-  #
-  #    def receive_data data
-  #      puts "We received #{data.length} bytes from the remote peer."
-  #      puts "We're going to stop the event loop now."
-  #      EventMachine::stop_event_loop
-  #    end
-  #
-  #    def unbind
-  #      puts "A connection has terminated."
-  #    end
-  #  end
-  #
-  #  puts "We're starting the event loop now."
-  #  EventMachine.run {
-  #    EventMachine.connect "www.microsoft.com", 80, Redmond
-  #  }
-  #  puts "The event loop has stopped."
-  #
-  #  # This program will produce approximately the following output:
-  #  #
-  #  # We're starting the event loop now.
-  #  # We're sending a dumb HTTP request to the remote peer.
-  #  # We received 1440 bytes from the remote peer.
-  #  # We're going to stop the event loop now.
-  #  # A connection has terminated.
-  #  # The event loop has stopped.
+  #   # This program will produce approximately the following output:
+  #   #
+  #   # We're starting the event loop now.
+  #   # We're sending a dumb HTTP request to the remote peer.
+  #   # We received 1440 bytes from the remote peer.
+  #   # We're going to stop the event loop now.
+  #   # A connection has terminated.
+  #   # The event loop has stopped.
   #
   #
   def self.stop_event_loop
@@ -467,43 +468,43 @@ module EventMachine
   #
   # @example
   #
-  #  require 'rubygems'
-  #  require 'eventmachine'
+  #   require 'rubygems'
+  #   require 'eventmachine'
   #
-  #  # Here is an example of a server that counts lines of input from the remote
-  #  # peer and sends back the total number of lines received, after each line.
-  #  # Try the example with more than one client connection opened via telnet,
-  #  # and you will see that the line count increments independently on each
-  #  # of the client connections. Also very important to note, is that the
-  #  # handler for the receive_data function, which our handler redefines, may
-  #  # not assume that the data it receives observes any kind of message boundaries.
-  #  # Also, to use this example, be sure to change the server and port parameters
-  #  # to the start_server call to values appropriate for your environment.
-  #  module LineCounter
-  #    MaxLinesPerConnection = 10
+  #   # Here is an example of a server that counts lines of input from the remote
+  #   # peer and sends back the total number of lines received, after each line.
+  #   # Try the example with more than one client connection opened via telnet,
+  #   # and you will see that the line count increments independently on each
+  #   # of the client connections. Also very important to note, is that the
+  #   # handler for the receive_data function, which our handler redefines, may
+  #   # not assume that the data it receives observes any kind of message boundaries.
+  #   # Also, to use this example, be sure to change the server and port parameters
+  #   # to the start_server call to values appropriate for your environment.
+  #   module LineCounter
+  #     MaxLinesPerConnection = 10
   #
-  #    def post_init
-  #      puts "Received a new connection"
-  #      @data_received = ""
-  #      @line_count = 0
-  #    end
+  #     def post_init
+  #       puts "Received a new connection"
+  #       @data_received = ""
+  #       @line_count = 0
+  #     end
   #
-  #    def receive_data data
-  #      @data_received << data
-  #      while @data_received.slice!( /^[^\n]*[\n]/m )
-  #        @line_count += 1
-  #        send_data "received #{@line_count} lines so far\r\n"
-  #        @line_count == MaxLinesPerConnection and close_connection_after_writing
-  #      end
-  #    end
-  #  end
+  #     def receive_data data
+  #       @data_received << data
+  #       while @data_received.slice!( /^[^\n]*[\n]/m )
+  #         @line_count += 1
+  #         send_data "received #{@line_count} lines so far\r\n"
+  #         @line_count == MaxLinesPerConnection and close_connection_after_writing
+  #       end
+  #     end
+  #   end
   #
-  #  EventMachine.run {
-  #    host, port = "192.168.0.100", 8090
-  #    EventMachine.start_server host, port, LineCounter
-  #    puts "Now accepting connections on address #{host}, port #{port}..."
-  #    EventMachine.add_periodic_timer(10) { $stderr.write "*" }
-  #  }
+  #   EventMachine.run {
+  #     host, port = "192.168.0.100", 8090
+  #     EventMachine.start_server host, port, LineCounter
+  #     puts "Now accepting connections on address #{host}, port #{port}..."
+  #     EventMachine.add_periodic_timer(10) { $stderr.write "*" }
+  #   }
   #
   # @param [String] server         Host to bind to.
   # @param [Integer] port          Port to bind to.
@@ -575,50 +576,50 @@ module EventMachine
   #
   # @example
   #
-  #  # Here's a program which connects to a web server, sends a naive
-  #  # request, parses the HTTP header of the response, and then
-  #  # (antisocially) ends the event loop, which automatically drops the connection
-  #  # (and incidentally calls the connection's unbind method).
-  #  module DumbHttpClient
-  #    def post_init
-  #      send_data "GET / HTTP/1.1\r\nHost: _\r\n\r\n"
-  #      @data = ""
-  #      @parsed = false
-  #    end
+  #   # Here's a program which connects to a web server, sends a naive
+  #   # request, parses the HTTP header of the response, and then
+  #   # (antisocially) ends the event loop, which automatically drops the connection
+  #   # (and incidentally calls the connection's unbind method).
+  #   module DumbHttpClient
+  #     def post_init
+  #       send_data "GET / HTTP/1.1\r\nHost: _\r\n\r\n"
+  #       @data = ""
+  #       @parsed = false
+  #     end
   #
-  #    def receive_data data
-  #      @data << data
-  #      if !@parsed and @data =~ /[\n][\r]*[\n]/m
-  #        @parsed = true
-  #        puts "RECEIVED HTTP HEADER:"
-  #        $`.each {|line| puts ">>> #{line}" }
+  #     def receive_data data
+  #       @data << data
+  #       if !@parsed and @data =~ /[\n][\r]*[\n]/m
+  #         @parsed = true
+  #         puts "RECEIVED HTTP HEADER:"
+  #         $`.each {|line| puts ">>> #{line}" }
   #
-  #        puts "Now we'll terminate the loop, which will also close the connection"
-  #        EventMachine::stop_event_loop
-  #      end
-  #    end
+  #         puts "Now we'll terminate the loop, which will also close the connection"
+  #         EventMachine::stop_event_loop
+  #       end
+  #     end
   #
-  #    def unbind
-  #      puts "A connection has terminated"
-  #    end
-  #  end
+  #     def unbind
+  #       puts "A connection has terminated"
+  #     end
+  #   end
   #
-  #  EventMachine.run {
-  #    EventMachine.connect "www.bayshorenetworks.com", 80, DumbHttpClient
-  #  }
-  #  puts "The event loop has ended"
+  #   EventMachine.run {
+  #     EventMachine.connect "www.bayshorenetworks.com", 80, DumbHttpClient
+  #   }
+  #   puts "The event loop has ended"
   #
   #
   # @example Defining protocol handler as a class
   #
-  #  class MyProtocolHandler < EventMachine::Connection
-  #    def initialize *args
-  #      super
-  #      # whatever else you want to do here
-  #    end
+  #   class MyProtocolHandler < EventMachine::Connection
+  #     def initialize *args
+  #       super
+  #       # whatever else you want to do here
+  #     end
   #
-  #    # ...
-  #  end
+  #     # ...
+  #   end
   #
   #
   # @param [String] server         Host to connect to
@@ -699,32 +700,32 @@ module EventMachine
   #
   # @example
   #
-  #  module SimpleHttpClient
-  #    def notify_readable
-  #      header = @io.readline
+  #   module SimpleHttpClient
+  #     def notify_readable
+  #       header = @io.readline
   #
-  #      if header == "\r\n"
-  #        # detach returns the file descriptor number (fd == @io.fileno)
-  #        fd = detach
-  #      end
-  #    rescue EOFError
-  #      detach
-  #    end
+  #       if header == "\r\n"
+  #         # detach returns the file descriptor number (fd == @io.fileno)
+  #         fd = detach
+  #       end
+  #     rescue EOFError
+  #       detach
+  #     end
   #
-  #    def unbind
-  #      EM.next_tick do
-  #        # socket is detached from the eventloop, but still open
-  #        data = @io.read
-  #      end
-  #    end
-  #  end
+  #     def unbind
+  #       EM.next_tick do
+  #         # socket is detached from the eventloop, but still open
+  #         data = @io.read
+  #       end
+  #     end
+  #   end
   #
-  #  EventMachine.run {
-  #    sock = TCPSocket.new('site.com', 80)
-  #    sock.write("GET / HTTP/1.0\r\n\r\n")
-  #    conn = EventMachine.watch(sock, SimpleHttpClient)
-  #    conn.notify_readable = true
-  #  }
+  #   EventMachine.run {
+  #     sock = TCPSocket.new('site.com', 80)
+  #     sock.write("GET / HTTP/1.0\r\n\r\n")
+  #     conn = EventMachine.watch(sock, SimpleHttpClient)
+  #     conn.notify_readable = true
+  #   }
   #
   # @author Riham Aldakkak (eSpace Technologies)
   def EventMachine::watch io, handler=nil, *args, &blk
@@ -930,25 +931,25 @@ module EventMachine
   #
   # @example
   #
-  #  EventMachine.run {
-  #    EventMachine.connect("rubyeventmachine.com", 80)
-  #    # count will be 0 in this case, because connection is not
-  #    # established yet
-  #    count = EventMachine.connection_count
-  #  }
+  #   EventMachine.run {
+  #     EventMachine.connect("rubyeventmachine.com", 80)
+  #     # count will be 0 in this case, because connection is not
+  #     # established yet
+  #     count = EventMachine.connection_count
+  #   }
   #
   #
   # @example
   #
-  #  EventMachine.run {
-  #    EventMachine.connect("rubyeventmachine.com", 80)
+  #   EventMachine.run {
+  #     EventMachine.connect("rubyeventmachine.com", 80)
   #
-  #    EventMachine.next_tick {
-  #      # In this example, count will be 1 since the connection has been established in
-  #      # the next loop of the reactor.
-  #      count = EventMachine.connection_count
-  #    }
-  #  }
+  #     EventMachine.next_tick {
+  #       # In this example, count will be 1 since the connection has been established in
+  #       # the next loop of the reactor.
+  #       count = EventMachine.connection_count
+  #     }
+  #   }
   #
   # @return [Integer] Number of connections currently held by the reactor.
   def self.connection_count
@@ -1021,18 +1022,18 @@ module EventMachine
   #
   # @example
   #
-  #  operation = proc {
-  #    # perform a long-running operation here, such as a database query.
-  #    "result" # as usual, the last expression evaluated in the block will be the return value.
-  #  }
-  #  callback = proc {|result|
-  #    # do something with result here, such as send it back to a network client.
-  #  }
-  #  errback = proc {|error|
-  #    # do something with error here, such as re-raising or logging.
-  #  }
+  #   operation = proc {
+  #     # perform a long-running operation here, such as a database query.
+  #     "result" # as usual, the last expression evaluated in the block will be the return value.
+  #   }
+  #   callback = proc {|result|
+  #     # do something with result here, such as send it back to a network client.
+  #   }
+  #   errback = proc {|error|
+  #     # do something with error here, such as re-raising or logging.
+  #   }
   #
-  #  EventMachine.defer(operation, callback, errback)
+  #   EventMachine.defer(operation, callback, errback)
   #
   # @param [#call] op       An operation you want to offload to EventMachine thread pool
   # @param [#call] callback A callback that will be run on the event loop thread after `operation` finishes.
@@ -1174,22 +1175,22 @@ module EventMachine
   #
   # @example
   #
-  #  module RubyCounter
-  #    def post_init
-  #      # count up to 5
-  #      send_data "5\n"
-  #    end
-  #    def receive_data data
-  #      puts "ruby sent me: #{data}"
-  #    end
-  #    def unbind
-  #      puts "ruby died with exit status: #{get_status.exitstatus}"
-  #    end
-  #  end
+  #   module RubyCounter
+  #     def post_init
+  #       # count up to 5
+  #       send_data "5\n"
+  #     end
+  #     def receive_data data
+  #       puts "ruby sent me: #{data}"
+  #     end
+  #     def unbind
+  #       puts "ruby died with exit status: #{get_status.exitstatus}"
+  #     end
+  #   end
   #
-  #  EventMachine.run {
-  #    EventMachine.popen("ruby -e' $stdout.sync = true; gets.to_i.times{ |i| puts i+1; sleep 1 } '", RubyCounter)
-  #  }
+  #   EventMachine.run {
+  #     EventMachine.popen("ruby -e' $stdout.sync = true; gets.to_i.times{ |i| puts i+1; sleep 1 } '", RubyCounter)
+  #   }
   #
   # @note This method is not supported on Microsoft Windows
   # @see EventMachine::DeferrableChildProcess
@@ -1268,37 +1269,37 @@ module EventMachine
   #
   # @example
   #
-  #  # Before running this example, make sure we have a file to monitor:
-  #  # $ echo "bar" > /tmp/foo
+  #   # Before running this example, make sure we have a file to monitor:
+  #   # $ echo "bar" > /tmp/foo
   #
-  #  module Handler
-  #    def file_modified
-  #      puts "#{path} modified"
-  #    end
+  #   module Handler
+  #     def file_modified
+  #       puts "#{path} modified"
+  #     end
   #
-  #    def file_moved
-  #      puts "#{path} moved"
-  #    end
+  #     def file_moved
+  #       puts "#{path} moved"
+  #     end
   #
-  #    def file_deleted
-  #      puts "#{path} deleted"
-  #    end
+  #     def file_deleted
+  #       puts "#{path} deleted"
+  #     end
   #
-  #    def unbind
-  #      puts "#{path} monitoring ceased"
-  #    end
-  #  end
+  #     def unbind
+  #       puts "#{path} monitoring ceased"
+  #     end
+  #   end
   #
-  #  # for efficient file watching, use kqueue on Mac OS X
-  #  EventMachine.kqueue = true if EventMachine.kqueue?
+  #   # for efficient file watching, use kqueue on Mac OS X
+  #   EventMachine.kqueue = true if EventMachine.kqueue?
   #
-  #  EventMachine.run {
-  #    EventMachine.watch_file("/tmp/foo", Handler)
-  #  }
+  #   EventMachine.run {
+  #     EventMachine.watch_file("/tmp/foo", Handler)
+  #   }
   #
-  #  # $ echo "baz" >> /tmp/foo    =>    "/tmp/foo modified"
-  #  # $ mv /tmp/foo /tmp/oof      =>    "/tmp/foo moved"
-  #  # $ rm /tmp/oof               =>    "/tmp/foo deleted"
+  #   # $ echo "baz" >> /tmp/foo    =>    "/tmp/foo modified"
+  #   # $ mv /tmp/foo /tmp/oof      =>    "/tmp/foo moved"
+  #   # $ rm /tmp/oof               =>    "/tmp/foo deleted"
   #
   # @note The ability to pick up on the new filename after a rename is not yet supported.
   #       Calling #path will always return the filename you originally used.
@@ -1321,18 +1322,18 @@ module EventMachine
   #
   # @example
   #
-  #  module ProcessWatcher
-  #    def process_exited
-  #      put 'the forked child died!'
-  #    end
-  #  end
+  #   module ProcessWatcher
+  #     def process_exited
+  #       put 'the forked child died!'
+  #     end
+  #   end
   #
-  #  pid = fork{ sleep }
+  #   pid = fork{ sleep }
   #
-  #  EventMachine.run {
-  #    EventMachine.watch_process(pid, ProcessWatcher)
-  #    EventMachine.add_timer(1){ Process.kill('TERM', pid) }
-  #  }
+  #   EventMachine.run {
+  #     EventMachine.watch_process(pid, ProcessWatcher)
+  #     EventMachine.add_timer(1){ Process.kill('TERM', pid) }
+  #   }
   #
   # @param [Integer]       pid     PID of the process to watch.
   # @param [Class, Module] handler A class or module that implements event handlers associated with the file.
@@ -1385,40 +1386,40 @@ module EventMachine
   #
   # @example
   #
-  #  module ProxyConnection
-  #    def initialize(client, request)
-  #      @client, @request = client, request
-  #    end
+  #   module ProxyConnection
+  #     def initialize(client, request)
+  #       @client, @request = client, request
+  #     end
   #
-  #    def post_init
-  #      EM::enable_proxy(self, @client)
-  #    end
+  #     def post_init
+  #       EM::enable_proxy(self, @client)
+  #     end
   #
-  #    def connection_completed
-  #      send_data @request
-  #    end
+  #     def connection_completed
+  #       send_data @request
+  #     end
   #
-  #    def proxy_target_unbound
-  #      close_connection
-  #    end
+  #     def proxy_target_unbound
+  #       close_connection
+  #     end
   #
-  #    def unbind
-  #      @client.close_connection_after_writing
-  #    end
-  #  end
+  #     def unbind
+  #       @client.close_connection_after_writing
+  #     end
+  #   end
   #
-  #  module ProxyServer
-  #    def receive_data(data)
-  #      (@buf ||= "") << data
-  #      if @buf =~ /\r\n\r\n/ # all http headers received
-  #        EventMachine.connect("10.0.0.15", 80, ProxyConnection, self, data)
-  #      end
-  #    end
-  #  end
+  #   module ProxyServer
+  #     def receive_data(data)
+  #       (@buf ||= "") << data
+  #       if @buf =~ /\r\n\r\n/ # all http headers received
+  #         EventMachine.connect("10.0.0.15", 80, ProxyConnection, self, data)
+  #       end
+  #     end
+  #   end
   #
-  #  EventMachine.run {
-  #    EventMachine.start_server("127.0.0.1", 8080, ProxyServer)
-  #  }
+  #   EventMachine.run {
+  #     EventMachine.start_server("127.0.0.1", 8080, ProxyServer)
+  #   }
   #
   # @param [EventMachine::Connection] from    Source of data to be proxies/streamed.
   # @param [EventMachine::Connection] to      Destination of data to be proxies/streamed.


### PR DESCRIPTION
Adjusts doc/comments for correct parsing.  Note differences in first 'Overview' section.

See
(old) http://www.rubydoc.info/gems/eventmachine/EventMachine/Completion
(new) https://msp-greg.github.io/eventmachine/EventMachine/Completion.html

and

(old) http://www.rubydoc.info/gems/eventmachine/EventMachine/Completion
(new) https://msp-greg.github.io/eventmachine/EventMachine.html

(old) is YARD, (new) is my doc site, which is based on YARD.