### PR TITLE
Add Ruby 2.5 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ language: ruby
 sudo: false
 dist: trusty
 rvm:
+  - 2.5
   - 2.4
   - 2.3
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ bundler_args: --without documentation
 script: bundle exec rake compile test
 before_install:
   - 'if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install openssl; fi'
+  - gem update bundler
 env:
   global:
     - TESTOPTS=-v


### PR DESCRIPTION
Let's add Ruby 2.5 on Travis CI, as the preview version was released.
https://www.ruby-lang.org/en/news/2017/10/10/ruby-2-5-0-preview1-released/
