### PR TITLE
Add Travis build status badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# About EventMachine  [![Code Climate](https://codeclimate.com/github/eventmachine/eventmachine.svg)](https://codeclimate.com/github/eventmachine/eventmachine)
+# About EventMachine  [![Build Status](https://travis-ci.org/eventmachine/eventmachine.svg?branch=master)](https://travis-ci.org/eventmachine/eventmachine) [![Code Climate Maintainability](https://api.codeclimate.com/v1/badges/e9b0603462905d5b9118/maintainability)](https://codeclimate.com/github/eventmachine/eventmachine/maintainability)
 
 
 ## What is EventMachine ##


### PR DESCRIPTION
Shall we add Travis build status badge because I want to see Travis page casually?

You can see the modified README here.
https://github.com/junaruga/eventmachine/tree/feature/travis-status-badge

