### PR TITLE
Update .travis.yml to pass tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ rvm:
   - 2.1
   - 2.0.0
   - 1.9.3
+  - 1.9.2
   - ruby-head
 #  - rbx
 #  - rbx-2
+#  - rbx-3
 #  - jruby-1.7
 #  - jruby-9
 matrix:
@@ -27,6 +29,7 @@ matrix:
   allow_failures:
 #    - rvm: rbx
 #    - rvm: rbx-2
+#    - rvm: rbx-3
     - rvm: ruby-head
     - rvm: 2.0.0
     - rvm: 2.0.0
@@ -36,8 +39,6 @@ matrix:
 #    - rvm: jruby-9
   include:
     - rvm: 1.8.7
-      dist: precise
-    - rvm: 1.9.2
       dist: precise
     - rvm: 2.0.0
       os: osx


### PR DESCRIPTION
Let me fix this.
Maybe.
* Ruby 1.9.2 on trusty is available.
* rbx-3 on trusty is available.

I referred rspec-core's case.
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://travis-ci.org/rspec/rspec-core
