### PR TITLE
modified localhost string to set to the localhost ip address

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -120,16 +120,16 @@ module EventMachine
   # @example Starting EventMachine event loop in the current thread to run the "Hello, world"-like Echo server example
   #
   #   #!/usr/bin/env ruby
-  #   
+  #
   #   require 'rubygems' # or use Bundler.setup
   #   require 'eventmachine'
-  #   
+  #
   #   class EchoServer < EM::Connection
   #     def receive_data(data)
   #       send_data(data)
   #     end
   #   end
-  #   
+  #
   #   EventMachine.run do
   #     EventMachine.start_server("0.0.0.0", 10000, EchoServer)
   #   end
@@ -380,24 +380,24 @@ module EventMachine
   #
   #   require 'rubygems'
   #   require 'eventmachine'
-  #   
+  #
   #   module Redmond
   #     def post_init
   #       puts "We're sending a dumb HTTP request to the remote peer."
   #       send_data "GET / HTTP/1.1\r\nHost: www.microsoft.com\r\n\r\n"
   #     end
-  #   
+  #
   #     def receive_data data
   #       puts "We received #{data.length} bytes from the remote peer."
   #       puts "We're going to stop the event loop now."
   #       EventMachine::stop_event_loop
   #     end
-  #   
+  #
   #     def unbind
   #       puts "A connection has terminated."
   #     end
   #   end
-  #   
+  #
   #   puts "We're starting the event loop now."
   #   EventMachine.run {
   #     EventMachine.connect "www.microsoft.com", 80, Redmond
@@ -528,7 +528,7 @@ module EventMachine
     klass = klass_from_handler(Connection, handler, *args)
 
     s = if port
-          start_tcp_server server, port
+          start_tcp_server server = (server == "localhost" ?  "127.0.0.1" : server), port
         else
           start_unix_server server
         end


### PR DESCRIPTION
the way it is designed currently, the ip address is not used as the server name if you start a rails server with 

`rails s`

this passes the value of 'localhost' to start_server & start_tcp_server and in order for this to work it creates a system dependency on localhost being associated with the localhost ip, 127.0.0.1. in the /etc/hosts file.

This was not setup by default on my new Macosx High Sierra and is how I encountered this.

Not every system has this set up inherently and the error that is provide from the eventmachine implies that the server is already running and can be misleading.

Error:
```

/Users/[USER]/.rvm/gems/ruby-2.3.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:532:in `start_tcp_server': no acceptor (port is in use or requires root privileges) (RuntimeError)
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:532:in `start_server'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/thin-1.7.2/lib/thin/backends/tcp_server.rb:16:in `connect'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/thin-1.7.2/lib/thin/backends/base.rb:63:in `block in start'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:195:in `run_machine'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:195:in `run'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/thin-1.7.2/lib/thin/backends/base.rb:73:in `start'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/thin-1.7.2/lib/thin/server.rb:162:in `start'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/rack-1.6.9/lib/rack/handler/thin.rb:19:in `run'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/rack-1.6.9/lib/rack/server.rb:287:in `start'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/railties-4.2.7.1/lib/rails/commands/server.rb:80:in `start'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:80:in `block in server'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:75:in `tap'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:75:in `server'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /Users/[USER]/.rvm/gems/ruby-2.3.4/gems/railties-4.2.7.1/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:11:in `require'
	from bin/rails:11:in `<main>'




```