### PR TITLE
Expose outstanding timer count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ matrix:
 #    - rvm: jruby-1.7
 #    - rvm: jruby-9
   include:
-    - rvm: 1.8.7
-      dist: precise
     - rvm: 2.0.0
       os: osx
       osx_image: xcode8

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Rake 11.0 no longer supports Ruby 1.8.7 and Ruby 1.9.2
+# Rake 11.0 no longer supports Ruby 1.9.2
 if RUBY_VERSION < '1.9.3'
   gem 'rake', '< 11'
 else

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ EventMachine has been around since the early 2000s and is a mature and battle-te
 
 ## What platforms are supported by EventMachine? ##
 
-EventMachine supports Ruby 1.8.7 through 2.5, REE, JRuby and **works well on Windows** as well
+EventMachine supports Ruby 1.9.2 through 2.5, REE, JRuby and **works well on Windows** as well
 as many operating systems from the Unix family (Linux, Mac OS X, BSD flavors).
 
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -34,7 +34,6 @@ we recommend you to use [JRuby](http://jruby.org) when running these examples.
 
 This guide assumes you have one of the supported Ruby implementations installed:
 
- * Ruby 1.8.7
  * Ruby 1.9.2
  * [JRuby](http://jruby.org) (we recommend 1.6)
  * [Rubinius](http://rubini.us) 1.2 or higher

--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -96,13 +96,13 @@ extern "C" void evma_run_machine()
 }
 
 /********************************
-evma_get_outstanding_timer_count
+evma_get_timer_count
 ********************************/
 
-extern "C" const size_t evma_get_outstanding_timer_count ()
+extern "C" const size_t evma_get_timer_count ()
 {
-  ensure_eventmachine("evma_get_outstanding_timer_count");
-  return EventMachine->GetOutstandingTimerCount();
+  ensure_eventmachine("evma_get_timer_count");
+  return EventMachine->GetTimerCount();
 }
 
 /**************************

--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -95,6 +95,15 @@ extern "C" void evma_run_machine()
 	EventMachine->Run();
 }
 
+/********************************
+evma_get_outstanding_timer_count
+********************************/
+
+extern "C" const size_t evma_get_outstanding_timer_count ()
+{
+  ensure_eventmachine("evma_get_outstanding_timer_count");
+  return EventMachine->GetOutstandingTimerCount();
+}
 
 /**************************
 evma_install_oneshot_timer

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1149,7 +1149,7 @@ void EventMachine_t::_RunTimers()
 EventMachine_t::_GetNumberOfOutstandingTimers
 *********************************************/
 
-size_t EventMachine_t::GetOutstandingTimerCount()
+size_t EventMachine_t::GetTimerCount()
 {
     return Timers.size();
 }

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -1145,6 +1145,14 @@ void EventMachine_t::_RunTimers()
 	}
 }
 
+/*********************************************
+EventMachine_t::_GetNumberOfOutstandingTimers
+*********************************************/
+
+size_t EventMachine_t::GetOutstandingTimerCount()
+{
+    return Timers.size();
+}
 
 
 /***********************************

--- a/ext/em.h
+++ b/ext/em.h
@@ -142,7 +142,7 @@ class EventMachine_t
 		void ScheduleHalt();
 		bool Stopping();
 		void SignalLoopBreaker();
-		size_t GetOutstandingTimerCount();
+		size_t GetTimerCount();
 		const uintptr_t InstallOneshotTimer (uint64_t);
 		const uintptr_t ConnectToServer (const char *, int, const char *, int);
 		const uintptr_t ConnectToUnixServer (const char *);

--- a/ext/em.h
+++ b/ext/em.h
@@ -142,6 +142,7 @@ class EventMachine_t
 		void ScheduleHalt();
 		bool Stopping();
 		void SignalLoopBreaker();
+		size_t GetOutstandingTimerCount();
 		const uintptr_t InstallOneshotTimer (uint64_t);
 		const uintptr_t ConnectToServer (const char *, int, const char *, int);
 		const uintptr_t ConnectToUnixServer (const char *);

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -51,6 +51,7 @@ extern "C" {
 	bool evma_run_machine_once();
 	void evma_run_machine();
 	void evma_release_library();
+	const size_t evma_get_outstanding_timer_count ();
 	const uintptr_t evma_install_oneshot_timer (uint64_t milliseconds);
 	const uintptr_t evma_connect_to_server (const char *bind_addr, int bind_port, const char *server, int port);
 	const uintptr_t evma_connect_to_unix_server (const char *server);

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -51,7 +51,7 @@ extern "C" {
 	bool evma_run_machine_once();
 	void evma_run_machine();
 	void evma_release_library();
-	const size_t evma_get_outstanding_timer_count ();
+	const size_t evma_get_timer_count ();
 	const uintptr_t evma_install_oneshot_timer (uint64_t milliseconds);
 	const uintptr_t evma_connect_to_server (const char *bind_addr, int bind_port, const char *server, int port);
 	const uintptr_t evma_connect_to_unix_server (const char *server);

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -255,6 +255,14 @@ static VALUE t_run_machine (VALUE self UNUSED)
 	return Qnil;
 }
 
+/*****************************
+t_get_outstanding_timer_count
+*****************************/
+
+static VALUE t_get_outstanding_timer_count ()
+{
+    return SIZET2NUM (evma_get_outstanding_timer_count ());
+}
 
 /*******************
 t_add_oneshot_timer
@@ -1401,6 +1409,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "run_machine_once", (VALUE(*)(...))t_run_machine_once, 0);
 	rb_define_module_function (EmModule, "run_machine", (VALUE(*)(...))t_run_machine, 0);
 	rb_define_module_function (EmModule, "run_machine_without_threads", (VALUE(*)(...))t_run_machine, 0);
+	rb_define_module_function (EmModule, "get_outstanding_timer_count", (VALUE(*)(...))t_get_outstanding_timer_count, 0);
 	rb_define_module_function (EmModule, "add_oneshot_timer", (VALUE(*)(...))t_add_oneshot_timer, 1);
 	rb_define_module_function (EmModule, "start_tcp_server", (VALUE(*)(...))t_start_server, 2);
 	rb_define_module_function (EmModule, "stop_tcp_server", (VALUE(*)(...))t_stop_server, 1);

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -256,12 +256,12 @@ static VALUE t_run_machine (VALUE self UNUSED)
 }
 
 /*****************************
-t_get_outstanding_timer_count
+t_get_timer_count
 *****************************/
 
-static VALUE t_get_outstanding_timer_count ()
+static VALUE t_get_timer_count ()
 {
-    return SIZET2NUM (evma_get_outstanding_timer_count ());
+    return SIZET2NUM (evma_get_timer_count ());
 }
 
 /*******************
@@ -1409,7 +1409,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "run_machine_once", (VALUE(*)(...))t_run_machine_once, 0);
 	rb_define_module_function (EmModule, "run_machine", (VALUE(*)(...))t_run_machine, 0);
 	rb_define_module_function (EmModule, "run_machine_without_threads", (VALUE(*)(...))t_run_machine, 0);
-	rb_define_module_function (EmModule, "get_outstanding_timer_count", (VALUE(*)(...))t_get_outstanding_timer_count, 0);
+	rb_define_module_function (EmModule, "get_timer_count", (VALUE(*)(...))t_get_timer_count, 0);
 	rb_define_module_function (EmModule, "add_oneshot_timer", (VALUE(*)(...))t_add_oneshot_timer, 1);
 	rb_define_module_function (EmModule, "start_tcp_server", (VALUE(*)(...))t_start_server, 2);
 	rb_define_module_function (EmModule, "stop_tcp_server", (VALUE(*)(...))t_stop_server, 1);

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -508,7 +508,7 @@ module EventMachine
       initialize_for_run
     end
 
-    def get_outstanding_timer_count
+    def get_timer_count
       @timers.size
     end
 

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -508,6 +508,10 @@ module EventMachine
       initialize_for_run
     end
 
+    def get_outstanding_timer_count
+      @timers.size
+    end
+
     def install_oneshot_timer interval
       uuid = UuidGenerator::generate
       #@timers << [Time.now + interval, uuid]

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -114,7 +114,7 @@ desc "Build binary gems for Windows with rake-compiler-dock"
 task 'gem:windows' do
   require 'rake_compiler_dock'
   RakeCompilerDock.sh <<-EOT
-    RUBY_CC_VERSION="${RUBY_CC_VERSION//1.8.7/}"
+    RUBY_CC_VERSION="${RUBY_CC_VERSION//1.9.2/}"
     bundle && rake cross native gem
   EOT
 end

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -7,11 +7,7 @@ if EM.ssl?
   class TestSslProtocols < Test::Unit::TestCase
 
     # equal to base METHODS, downcased, like ["tlsv1, "tlsv1_1", "tlsv1_2"]
-    if RUBY_VERSION == "1.8.7"
-      SSL_AVAIL = ["sslv3", "tlsv1"]
-    else
-      SSL_AVAIL = ::OpenSSL::SSL::SSLContext::METHODS.select { |i| i =~ /[^\d]\d\z/ }.map { |i| i.to_s.downcase } 
-    end
+    SSL_AVAIL = ::OpenSSL::SSL::SSLContext::METHODS.select { |i| i =~ /[^\d]\d\z/ }.map { |i| i.to_s.downcase }
 
     libr_vers =  OpenSSL.const_defined?(:OPENSSL_LIBRARY_VERSION) ?
       OpenSSL::OPENSSL_VERSION : 'na'

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -101,6 +101,26 @@ class TestTimers < Test::Unit::TestCase
     }
   end
 
+  def test_add_timer_increments_outstanding_timer_count
+    EM.run {
+      n = EM.get_outstanding_timer_count
+      EM::Timer.new(0.01) {
+        EM.stop
+      }
+      assert_equal(n+1, EM.get_outstanding_timer_count)
+    }
+  end
+
+  def test_timer_run_decrements_timer_count
+    EM.run {
+      n = EM.get_outstanding_timer_count
+      EM::Timer.new(0.01) {
+        assert_equal(n, EM.get_outstanding_timer_count)
+        EM.stop
+      }
+    }
+  end
+
   # This test is only applicable to compiled versions of the reactor.
   # Pure ruby and java versions have no built-in limit on the number of outstanding timers.
   unless [:pure_ruby, :java].include? EM.library_type

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -101,7 +101,7 @@ class TestTimers < Test::Unit::TestCase
     }
   end
 
-  def test_add_timer_increments_outstanding_timer_count
+  def test_add_timer_increments_timer_count
     EM.run {
       n = EM.get_timer_count
       EM::Timer.new(0.01) {

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -103,19 +103,19 @@ class TestTimers < Test::Unit::TestCase
 
   def test_add_timer_increments_outstanding_timer_count
     EM.run {
-      n = EM.get_outstanding_timer_count
+      n = EM.get_timer_count
       EM::Timer.new(0.01) {
         EM.stop
       }
-      assert_equal(n+1, EM.get_outstanding_timer_count)
+      assert_equal(n+1, EM.get_timer_count)
     }
   end
 
   def test_timer_run_decrements_timer_count
     EM.run {
-      n = EM.get_outstanding_timer_count
+      n = EM.get_timer_count
       EM::Timer.new(0.01) {
-        assert_equal(n, EM.get_outstanding_timer_count)
+        assert_equal(n, EM.get_timer_count)
         EM.stop
       }
     }


### PR DESCRIPTION
EventMachine has a (dynamically adjustable) limit on the number of outstanding timers. To reduce the risk of hitting this limit, we need to see how close we are to the limit. This PR exposes the current number of outstanding timers as `EventMachine::get_outstanding_timer_count`.