### PR TITLE
Remove using namespace std; and be explicit with std:: prefixes

### DIFF
--- a/ext/binder.cpp
+++ b/ext/binder.cpp
@@ -22,7 +22,7 @@ See the file COPYING for complete licensing information.
 #define DEV_URANDOM "/dev/urandom"
 
 
-map<uintptr_t, Bindable_t*> Bindable_t::BindingBag;
+std::map<uintptr_t, Bindable_t*> Bindable_t::BindingBag;
 
 
 /********************************
@@ -92,7 +92,7 @@ STATIC: Bindable_t::GetObject
 
 Bindable_t *Bindable_t::GetObject (const uintptr_t binding)
 {
-	map<uintptr_t, Bindable_t*>::const_iterator i = BindingBag.find (binding);
+	std::map<uintptr_t, Bindable_t*>::const_iterator i = BindingBag.find (binding);
 	if (i != BindingBag.end())
 		return i->second;
 	else

--- a/ext/binder.h
+++ b/ext/binder.h
@@ -32,7 +32,7 @@ class Bindable_t
 	public:
 		static uintptr_t CreateBinding();
 		static Bindable_t *GetObject (const uintptr_t);
-		static map<uintptr_t, Bindable_t*> BindingBag;
+		static std::map<uintptr_t, Bindable_t*> BindingBag;
 
 	public:
 		Bindable_t();

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -320,7 +320,7 @@ void EventableDescriptor::_GenericInboundDispatch(const char *buf, unsigned long
 
 	if (ProxyTarget) {
 		if (BytesToProxy > 0) {
-			unsigned long proxied = min(BytesToProxy, size);
+			unsigned long proxied = std::min(BytesToProxy, size);
 			ProxyTarget->SendOutboundData(buf, proxied);
 			ProxiedBytes += (unsigned long) proxied;
 			BytesToProxy -= proxied;
@@ -1148,7 +1148,7 @@ void ConnectionDescriptor::_WriteOutboundData()
 	#ifdef HAVE_WRITEV
 	if (!err) {
 		unsigned int sent = bytes_written;
-		deque<OutboundPage>::iterator op = OutboundPages.begin();
+		std::deque<OutboundPage>::iterator op = OutboundPages.begin();
 
 		for (int i = 0; i < iovcnt; i++) {
 			if (iov[i].iov_len <= sent) {

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -251,7 +251,7 @@ class ConnectionDescriptor: public EventableDescriptor
 		bool bReadAttemptedAfterClose;
 		bool bWriteAttemptedAfterClose;
 
-		deque<OutboundPage> OutboundPages;
+		std::deque<OutboundPage> OutboundPages;
 		int OutboundDataSize;
 
 		#ifdef WITH_SSL
@@ -326,7 +326,7 @@ class DatagramDescriptor: public EventableDescriptor
 			struct sockaddr_in6 From;
 		};
 
-		deque<OutboundPage> OutboundPages;
+		std::deque<OutboundPage> OutboundPages;
 		int OutboundDataSize;
 
 		struct sockaddr_in6 ReturnAddress;
@@ -394,7 +394,7 @@ class PipeDescriptor: public EventableDescriptor
 	protected:
 		bool bReadAttemptedAfterClose;
 
-		deque<OutboundPage> OutboundPages;
+		std::deque<OutboundPage> OutboundPages;
 		int OutboundDataSize;
 
 		pid_t SubprocessPid;

--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -176,7 +176,7 @@ EventMachine_t::~EventMachine_t()
 
 	// Remove any file watch descriptors
 	while(!Files.empty()) {
-		map<int, Bindable_t*>::iterator f = Files.begin();
+		std::map<int, Bindable_t*>::iterator f = Files.begin();
 		UnwatchFile (f->first);
 	}
 
@@ -506,7 +506,7 @@ void EventMachine_t::_DispatchHeartbeats()
 	const EventableDescriptor *head = NULL;
 
 	while (true) {
-		multimap<uint64_t,EventableDescriptor*>::iterator i = Heartbeats.begin();
+		std::multimap<uint64_t,EventableDescriptor*>::iterator i = Heartbeats.begin();
 		if (i == Heartbeats.end())
 			break;
 		if (i->first > MyCurrentLoopTime)
@@ -534,9 +534,9 @@ void EventMachine_t::QueueHeartbeat(EventableDescriptor *ed)
 
 	if (heartbeat) {
 		#ifndef HAVE_MAKE_PAIR
-		Heartbeats.insert (multimap<uint64_t,EventableDescriptor*>::value_type (heartbeat, ed));
+		Heartbeats.insert (std::multimap<uint64_t,EventableDescriptor*>::value_type (heartbeat, ed));
 		#else
-		Heartbeats.insert (make_pair (heartbeat, ed));
+		Heartbeats.insert (std::make_pair (heartbeat, ed));
 		#endif
 	}
 }
@@ -547,8 +547,8 @@ EventMachine_t::ClearHeartbeat
 
 void EventMachine_t::ClearHeartbeat(uint64_t key, EventableDescriptor* ed)
 {
-	multimap<uint64_t,EventableDescriptor*>::iterator it;
-	pair<multimap<uint64_t,EventableDescriptor*>::iterator,multimap<uint64_t,EventableDescriptor*>::iterator> ret;
+	std::multimap<uint64_t,EventableDescriptor*>::iterator it;
+	std::pair<std::multimap<uint64_t,EventableDescriptor*>::iterator,std::multimap<uint64_t,EventableDescriptor*>::iterator> ret;
 	ret = Heartbeats.equal_range (key);
 	for (it = ret.first; it != ret.second; ++it) {
 		if (it->second == ed) {
@@ -747,7 +747,7 @@ void EventMachine_t::_RunKqueueOnce()
 				else if (ke->filter == EVFILT_WRITE)
 					ed->Write();
 				else
-					cerr << "Discarding unknown kqueue event " << ke->filter << endl;
+					std::cerr << "Discarding unknown kqueue event " << ke->filter << std::endl;
 
 				break;
 		}
@@ -786,12 +786,12 @@ timeval EventMachine_t::_TimeTilNextEvent()
 	uint64_t current_time = GetRealTime();
 
 	if (!Heartbeats.empty()) {
-		multimap<uint64_t,EventableDescriptor*>::iterator heartbeats = Heartbeats.begin();
+		std::multimap<uint64_t,EventableDescriptor*>::iterator heartbeats = Heartbeats.begin();
 		next_event = heartbeats->first;
 	}
 
 	if (!Timers.empty()) {
-		multimap<uint64_t,Timer_t>::iterator timers = Timers.begin();
+		std::multimap<uint64_t,Timer_t>::iterator timers = Timers.begin();
 		if (next_event == 0 || timers->first < next_event)
 			next_event = timers->first;
 	}
@@ -1134,7 +1134,7 @@ void EventMachine_t::_RunTimers()
 	// one that hasn't expired yet.
 
 	while (true) {
-		multimap<uint64_t,Timer_t>::iterator i = Timers.begin();
+		std::multimap<uint64_t,Timer_t>::iterator i = Timers.begin();
 		if (i == Timers.end())
 			break;
 		if (i->first > MyCurrentLoopTime)
@@ -1161,9 +1161,9 @@ const uintptr_t EventMachine_t::InstallOneshotTimer (uint64_t milliseconds)
 
 	Timer_t t;
 	#ifndef HAVE_MAKE_PAIR
-	multimap<uint64_t,Timer_t>::iterator i = Timers.insert (multimap<uint64_t,Timer_t>::value_type (fire_at, t));
+	std::multimap<uint64_t,Timer_t>::iterator i = Timers.insert (std::multimap<uint64_t,Timer_t>::value_type (fire_at, t));
 	#else
-	multimap<uint64_t,Timer_t>::iterator i = Timers.insert (make_pair (fire_at, t));
+	std::multimap<uint64_t,Timer_t>::iterator i = Timers.insert (std::make_pair (fire_at, t));
 	#endif
 	return i->second.GetBinding();
 }
@@ -1840,7 +1840,7 @@ void EventMachine_t::_ModifyDescriptors()
 
 	#ifdef HAVE_EPOLL
 	if (Poller == Poller_Epoll) {
-		set<EventableDescriptor*>::iterator i = ModifiedDescriptors.begin();
+		std::set<EventableDescriptor*>::iterator i = ModifiedDescriptors.begin();
 		while (i != ModifiedDescriptors.end()) {
 			assert (*i);
 			_ModifyEpollEvent (*i);
@@ -1851,7 +1851,7 @@ void EventMachine_t::_ModifyDescriptors()
 
 	#ifdef HAVE_KQUEUE
 	if (Poller == Poller_Kqueue) {
-		set<EventableDescriptor*>::iterator i = ModifiedDescriptors.begin();
+		std::set<EventableDescriptor*>::iterator i = ModifiedDescriptors.begin();
 		while (i != ModifiedDescriptors.end()) {
 			assert (*i);
 			if ((*i)->GetKqueueArmWrite())
@@ -2129,7 +2129,7 @@ const uintptr_t EventMachine_t::WatchPid (int pid)
 		throw std::runtime_error(errbuf);
 	}
 	Bindable_t* b = new Bindable_t();
-	Pids.insert(make_pair (pid, b));
+	Pids.insert(std::make_pair (pid, b));
 
 	return b->GetBinding();
 }
@@ -2166,7 +2166,7 @@ void EventMachine_t::UnwatchPid (int pid)
 
 void EventMachine_t::UnwatchPid (const uintptr_t sig)
 {
-	for(map<int, Bindable_t*>::iterator i=Pids.begin(); i != Pids.end(); i++)
+	for(std::map<int, Bindable_t*>::iterator i=Pids.begin(); i != Pids.end(); i++)
 	{
 		if (i->second->GetBinding() == sig) {
 			UnwatchPid (i->first);
@@ -2228,7 +2228,7 @@ const uintptr_t EventMachine_t::WatchFile (const char *fpath)
 
 	if (wd != -1) {
 		Bindable_t* b = new Bindable_t();
-		Files.insert(make_pair (wd, b));
+		Files.insert(std::make_pair (wd, b));
 
 		return b->GetBinding();
 	}
@@ -2262,7 +2262,7 @@ void EventMachine_t::UnwatchFile (int wd)
 
 void EventMachine_t::UnwatchFile (const uintptr_t sig)
 {
-	for(map<int, Bindable_t*>::iterator i=Files.begin(); i != Files.end(); i++)
+	for(std::map<int, Bindable_t*>::iterator i=Files.begin(); i != Files.end(); i++)
 	{
 		if (i->second->GetBinding() == sig) {
 			UnwatchFile (i->first);
@@ -2293,7 +2293,7 @@ void EventMachine_t::_ReadInotifyEvents()
 		int current = 0;
 		while (current < returned) {
 			struct inotify_event* event = (struct inotify_event*)(buffer+current);
-			map<int, Bindable_t*>::const_iterator bindable = Files.find(event->wd);
+			std::map<int, Bindable_t*>::const_iterator bindable = Files.find(event->wd);
 			if (bindable != Files.end()) {
 				if (event->mask & (IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVE)){
 					(*EventCallback)(bindable->second->GetBinding(), EM_CONNECTION_READ, "modified", 8);

--- a/ext/em.h
+++ b/ext/em.h
@@ -236,14 +236,14 @@ class EventMachine_t
 		class Timer_t: public Bindable_t {
 		};
 
-		multimap<uint64_t, Timer_t> Timers;
-		multimap<uint64_t, EventableDescriptor*> Heartbeats;
-		map<int, Bindable_t*> Files;
-		map<int, Bindable_t*> Pids;
-		vector<EventableDescriptor*> Descriptors;
-		vector<EventableDescriptor*> NewDescriptors;
-		vector<EventableDescriptor*> DescriptorsToDelete;
-		set<EventableDescriptor*> ModifiedDescriptors;
+		std::multimap<uint64_t, Timer_t> Timers;
+		std::multimap<uint64_t, EventableDescriptor*> Heartbeats;
+		std::map<int, Bindable_t*> Files;
+		std::map<int, Bindable_t*> Pids;
+		std::vector<EventableDescriptor*> Descriptors;
+		std::vector<EventableDescriptor*> NewDescriptors;
+		std::vector<EventableDescriptor*> DescriptorsToDelete;
+		std::set<EventableDescriptor*> ModifiedDescriptors;
 
 		SOCKET LoopBreakerReader;
 		SOCKET LoopBreakerWriter;

--- a/ext/fastfilereader/mapper.cpp
+++ b/ext/fastfilereader/mapper.cpp
@@ -30,13 +30,12 @@ See the file COPYING for complete licensing information.
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include <iostream>
-#include "unistd.h"
 #include <string>
 #include <cstring>
 #include <stdexcept>
-using namespace std;
 
 #include "mapper.h"
 
@@ -44,7 +43,7 @@ using namespace std;
 Mapper_t::Mapper_t
 ******************/
 
-Mapper_t::Mapper_t (const string &filename)
+Mapper_t::Mapper_t (const std::string &filename)
 {
 	/* We ASSUME we can open the file.
 	 * (More precisely, we assume someone else checked before we got here.)
@@ -52,11 +51,11 @@ Mapper_t::Mapper_t (const string &filename)
 
 	Fd = open (filename.c_str(), O_RDONLY);
 	if (Fd < 0)
-		throw runtime_error (strerror (errno));
+		throw std::runtime_error (strerror (errno));
 
 	struct stat st;
 	if (fstat (Fd, &st))
-		throw runtime_error (strerror (errno));
+		throw std::runtime_error (strerror (errno));
 	FileSize = st.st_size;
 
 	#ifdef OS_WIN32
@@ -65,7 +64,7 @@ Mapper_t::Mapper_t (const string &filename)
 	MapPoint = (const char*) mmap (0, FileSize, PROT_READ, MAP_SHARED, Fd, 0);
 	#endif
 	if (MapPoint == MAP_FAILED)
-		throw runtime_error (strerror (errno));
+		throw std::runtime_error (strerror (errno));
 }
 
 
@@ -128,7 +127,6 @@ const char *Mapper_t::GetChunk (unsigned start)
 #include <iostream>
 #include <string>
 #include <stdexcept>
-using namespace std;
 
 #include "mapper.h"
 
@@ -150,7 +148,7 @@ Mapper_t::Mapper_t (const string &filename)
 	hFile = CreateFile (filename.c_str(), GENERIC_READ|GENERIC_WRITE, FILE_SHARE_DELETE|FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
 	if (hFile == INVALID_HANDLE_VALUE)
-		throw runtime_error ("File not found");
+		throw std::runtime_error ("File not found");
 
 	BY_HANDLE_FILE_INFORMATION i;
 	if (GetFileInformationByHandle (hFile, &i))
@@ -158,7 +156,7 @@ Mapper_t::Mapper_t (const string &filename)
 
 	hMapping = CreateFileMapping (hFile, NULL, PAGE_READWRITE, 0, 0, NULL);
 	if (!hMapping)
-		throw runtime_error ("File not mapped");
+		throw std::runtime_error ("File not mapped");
 
 	#ifdef OS_WIN32
 	MapPoint = (char*) MapViewOfFile (hMapping, FILE_MAP_WRITE, 0, 0, 0);
@@ -166,7 +164,7 @@ Mapper_t::Mapper_t (const string &filename)
 	MapPoint = (const char*) MapViewOfFile (hMapping, FILE_MAP_WRITE, 0, 0, 0);
 	#endif
 	if (!MapPoint)
-		throw runtime_error ("Mappoint not read");
+		throw std::runtime_error ("Mappoint not read");
 }
 
 

--- a/ext/fastfilereader/mapper.h
+++ b/ext/fastfilereader/mapper.h
@@ -29,7 +29,7 @@ class Mapper_t
 class Mapper_t
 {
 	public:
-		Mapper_t (const string&);
+		Mapper_t (const std::string&);
 		virtual ~Mapper_t();
 
 		const char *GetChunk (unsigned);

--- a/ext/fastfilereader/rubymain.cpp
+++ b/ext/fastfilereader/rubymain.cpp
@@ -21,7 +21,6 @@ See the file COPYING for complete licensing information.
 
 #include <iostream>
 #include <stdexcept>
-using namespace std;
 
 #include <ruby.h>
 #include "mapper.h"

--- a/ext/page.cpp
+++ b/ext/page.cpp
@@ -95,7 +95,7 @@ void PageList::Push (const char *buf, int size)
 	if (buf && (size > 0)) {
 		char *copy = (char*) malloc (size);
 		if (!copy)
-			throw runtime_error ("no memory in pagelist");
+			throw std::runtime_error ("no memory in pagelist");
 		memcpy (copy, buf, size);
 		Pages.push_back (Page (copy, size));
 	}

--- a/ext/page.h
+++ b/ext/page.h
@@ -44,7 +44,7 @@ class PageList
 		void PopFront();
 
 	private:
-		deque<Page> Pages;
+		std::deque<Page> Pages;
 };
 
 

--- a/ext/project.h
+++ b/ext/project.h
@@ -115,8 +115,6 @@ typedef int SOCKET;
 #include <stdint.h>
 #endif
 
-using namespace std;
-
 #ifdef WITH_SSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -120,7 +120,7 @@ static void InitializeDefaultCredentials()
 SslContext_t::SslContext_t
 **************************/
 
-SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version) :
+SslContext_t::SslContext_t (bool is_server, const std::string &privkeyfile, const std::string &certchainfile, const std::string &cipherlist, const std::string &ecdh_curve, const std::string &dhparam, int ssl_version) :
 	bIsServer (is_server),
 	pCtx (NULL),
 	PrivateKey (NULL),
@@ -219,7 +219,7 @@ SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const str
 				BIO_free(bio);
 				char buf [500];
 				snprintf (buf, sizeof(buf)-1, "dhparam: PEM_read_bio_DHparams(%s) failed", dhparam.c_str());
-				throw new std::runtime_error(buf);
+				throw std::runtime_error (buf);
 			}
 
 			SSL_CTX_set_tmp_dh(pCtx, dh);
@@ -304,7 +304,7 @@ SslContext_t::~SslContext_t()
 SslBox_t::SslBox_t
 ******************/
 
-SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const string &snihostname, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version, const uintptr_t binding):
+SslBox_t::SslBox_t (bool is_server, const std::string &privkeyfile, const std::string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const std::string &snihostname, const std::string &cipherlist, const std::string &ecdh_curve, const std::string &dhparam, int ssl_version, const uintptr_t binding):
 	bIsServer (is_server),
 	bHandshakeCompleted (false),
 	bVerifyPeer (verify_peer),

--- a/ext/ssl.h
+++ b/ext/ssl.h
@@ -33,7 +33,7 @@ class SslContext_t
 class SslContext_t
 {
 	public:
-		SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version);
+		SslContext_t (bool is_server, const std::string &privkeyfile, const std::string &certchainfile, const std::string &cipherlist, const std::string &ecdh_curve, const std::string &dhparam, int ssl_version);
 		virtual ~SslContext_t();
 
 	private:
@@ -61,7 +61,7 @@ class SslBox_t
 class SslBox_t
 {
 	public:
-		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const string &snihostname, const string &cipherlist, const string &ecdh_curve, const string &dhparam, int ssl_version, const uintptr_t binding);
+		SslBox_t (bool is_server, const std::string &privkeyfile, const std::string &certchainfile, bool verify_peer, bool fail_if_no_peer_cert, const std::string &snihostname, const std::string &cipherlist, const std::string &ecdh_curve, const std::string &dhparam, int ssl_version, const uintptr_t binding);
 		virtual ~SslBox_t();
 
 		int PutPlaintext (const char*, int);


### PR DESCRIPTION
This resolves the conflict of socket bind() vs std::bind(), as more std:: functions may be introduced in future versions of C++.

Resolves #830