### PR TITLE
Switch from epoll_create to epoll_create1

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -386,16 +386,12 @@ void EventMachine_t::_InitializeLoopBreaker()
 
 	#ifdef HAVE_EPOLL
 	if (Poller == Poller_Epoll) {
-		epfd = epoll_create (MaxEpollDescriptors);
+		epfd = epoll_create1(EPOLL_CLOEXEC);
 		if (epfd == -1) {
 			char buf[200];
 			snprintf (buf, sizeof(buf)-1, "unable to create epoll descriptor: %s", strerror(errno));
 			throw std::runtime_error (buf);
 		}
-		int cloexec = fcntl (epfd, F_GETFD, 0);
-		assert (cloexec >= 0);
-		cloexec |= FD_CLOEXEC;
-		fcntl (epfd, F_SETFD, cloexec);
 
 		assert (LoopBreakerReader >= 0);
 		LoopbreakDescriptor *ld = new LoopbreakDescriptor (LoopBreakerReader, this);

--- a/ext/em.h
+++ b/ext/em.h
@@ -228,7 +228,6 @@ class EventMachine_t
 
 	private:
 		enum {
-			MaxEpollDescriptors = 64*1024,
 			MaxEvents = 4096
 		};
 		int HeartbeatInterval;

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -205,7 +205,8 @@ when /darwin/
   CONFIG['LDSHARED'] = "$(CXX) " + CONFIG['LDSHARED'].split[1..-1].join(' ')
 
 when /linux/
-  add_define 'HAVE_EPOLL' if have_func('epoll_create', 'sys/epoll.h')
+  # epoll_create1 was added in Linux 2.6.27 and glibc 2.9
+  add_define 'HAVE_EPOLL' if have_func('epoll_create1', 'sys/epoll.h')
 
   # on Unix we need a g++ link, not gcc.
   CONFIG['LDSHARED'] = "$(CXX) -shared"


### PR DESCRIPTION
The original epoll_create took a size argument as a hint for how much
kernel space to allocate for events. Since Linux 2.6.8, the size
argument is ignored, but must be greater than zero.

Since we also need to set CLOEXEC on the epoll fd, there is a small
window between epoll_create and fcntl as they are separate function
calls. Since Linux 2.6.27 and glibc 2.9, epoll_create1 accepts the
CLOEXEC argument at creation time to eliminate this gap.

This drops support for epoll on RHEL 5 / CentOS 5, EOL was March 2017.

Resolves #770