### PR TITLE
Fix unbind exceptions

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -164,8 +164,6 @@ EventMachine_t::~EventMachine_t()
 {
 	// Run down descriptors
 	size_t i;
-	for (i = 0; i < DescriptorsToDelete.size(); i++)
-		delete DescriptorsToDelete[i];
 	for (i = 0; i < NewDescriptors.size(); i++)
 		delete NewDescriptors[i];
 	for (i = 0; i < Descriptors.size(); i++)
@@ -838,17 +836,6 @@ void EventMachine_t::_CleanupSockets()
 		EventableDescriptor *ed = Descriptors[i];
 		assert (ed);
 		if (ed->ShouldDelete()) {
-			DescriptorsToDelete.push_back(ed);
-		}
-		else
-			Descriptors [j++] = ed;
-	}
-	while ((size_t)j < Descriptors.size())
-		Descriptors.pop_back();
-
-	nSockets = DescriptorsToDelete.size();
-	for (i=0; i < nSockets; i++) {
-		EventableDescriptor *ed = DescriptorsToDelete[i];
 		#ifdef HAVE_EPOLL
 			if (Poller == Poller_Epoll) {
 				assert (epfd != -1);
@@ -864,9 +851,13 @@ void EventMachine_t::_CleanupSockets()
 				ModifiedDescriptors.erase(ed);
 			}
 		#endif
-		delete ed;
+			delete ed;
+		}
+		else
+			Descriptors [j++] = ed;
 	}
-	DescriptorsToDelete.clear();
+	while ((size_t)j < Descriptors.size())
+		Descriptors.pop_back();
 }
 
 /*********************************

--- a/ext/em.h
+++ b/ext/em.h
@@ -242,7 +242,6 @@ class EventMachine_t
 		std::map<int, Bindable_t*> Pids;
 		std::vector<EventableDescriptor*> Descriptors;
 		std::vector<EventableDescriptor*> NewDescriptors;
-		std::vector<EventableDescriptor*> DescriptorsToDelete;
 		std::set<EventableDescriptor*> ModifiedDescriptors;
 
 		SOCKET LoopBreakerReader;

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1492,13 +1492,9 @@ module EventMachine
             rescue Errno::EBADF, IOError
             end
           end
-        rescue Exception => e
-          if stopping?
-            @wrapped_exception = $!
-            stop
-          else
-            raise e
-          end
+        rescue
+          @wrapped_exception = $!
+          stop
         end
       elsif c = @acceptors.delete( conn_binding )
         # no-op

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1492,9 +1492,23 @@ module EventMachine
             rescue Errno::EBADF, IOError
             end
           end
-        rescue
-          @wrapped_exception = $!
-          stop
+        # As noted above, unbind absolutely must not raise an exception or the reactor will crash.
+        # If there is no EM.error_handler, or if the error_handler retrows, then stop the reactor,
+        # stash the exception in $wrapped_exception, and the exception will be raised after the
+        # reactor is cleaned up (see the last line of self.run).
+        rescue Exception => error
+          if instance_variable_defined? :@error_handler
+            begin
+              @error_handler.call error
+              # No need to stop unless error_handler rethrows
+            rescue Exception => error
+              @wrapped_exception = error
+              stop
+            end
+          else
+            @wrapped_exception = error
+            stop
+          end
         end
       elsif c = @acceptors.delete( conn_binding )
         # no-op

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -113,6 +113,9 @@ class TestBasic < Test::Unit::TestCase
       EM.start_server "127.0.0.1", @port
       EM.connect "127.0.0.1", @port, UnbindError
     }
+
+    # Remove the error handler before the next test
+    EM.error_handler(nil)
   end
 
   module BrsTestSrv
@@ -308,6 +311,9 @@ class TestBasic < Test::Unit::TestCase
       end
       EM.add_timer(0.001) { EM.stop }
     end
+
+    # Remove the error handler before the next test
+    EM.error_handler(nil)
 
     assert_equal 1, errors.size
     assert_equal [:first, :second], ticks

--- a/tests/test_pool.rb
+++ b/tests/test_pool.rb
@@ -56,7 +56,7 @@ class TestPool < Test::Unit::TestCase
     assert_equal pooled_res, pooled_res2
   end
 
-  def test_supports_custom_error_handler
+  def test_supports_custom_on_error
     eres = nil
     pool.on_error do |res|
       eres = res


### PR DESCRIPTION
Updates #327 to avoid crashing the machine on release.
Reverts #766 as it was not a fix to the root problem.
Fixes #620, #758, #761, #765, #792, #822.