### PR TITLE
Fix crashes on large numbers of connections

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -916,7 +916,7 @@ _SelectDataSelect
 static VALUE _SelectDataSelect (void *v)
 {
 	SelectData_t *sd = (SelectData_t*)v;
-	sd->nSockets = select (sd->maxsocket+1, rb_fd_ptr(&(sd->fdreads)), rb_fd_ptr(&(sd->fdwrites)), rb_fd_ptr(&(sd->fderrors)), &(sd->tv));
+	sd->nSockets = rb_fd_select (sd->maxsocket+1, &(sd->fdreads), &(sd->fdwrites), &(sd->fderrors), &(sd->tv));
 	return Qnil;
 }
 #endif


### PR DESCRIPTION
All three fd_set arguments to select must be large enough to modify
according to the length given in the first argument to select. This can
be done by calling rb_fd_resize on each of the fd_set arguments, which
happens to be exactly what rb_fd_select does!