### PR TITLE
Openssl 1.1.1 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ rvm:
 matrix:
   fast_finish: true
   allow_failures:
+    - rvm: ruby-head
 #    - rvm: rbx
 #    - rvm: rbx-2
 #    - rvm: rbx-3
-    - rvm: ruby-head
-    - rvm: 2.3
-      os: osx
 #    - rvm: jruby-1.7
 #    - rvm: jruby-9
   include:
+    - rvm: 2.6
+      os: osx
     - rvm: 2.3
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,25 @@
-sudo: false
-dist: trusty
+dist: xenial
 language: ruby
 bundler_args: --without documentation
-script: bundle exec rake compile test
-# Pin Rubygems to a working version. Sometimes it breaks upstream. Update now and then.
+
 before_install:
-  - 'if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install openssl; fi'
-  - gem update --system 2.7.4
-  - gem update bundler
+  # rubygems 2.7.8 and greater include bundler
+  # remove 2.7.0 code when Travis removes rubygems 2.7.8 from ruby-head build
+  - |
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
+    elif [ "$rv" \< "2.7" ]; then gem update --system --no-document --conservative
+    fi
+
+before_script:
+  - bundle exec rake compile
+
+script:
+  - bundle exec rake test
+
 env:
   global:
-    - TESTOPTS=-v
+    - TESTOPTS="-v  --no-show-detail-immediately"
 rvm:
   - 2.6
   - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Rake 11.0 no longer supports Ruby 1.8.7 and Ruby 1.9.2
-if RUBY_VERSION < '1.9.3'
-  gem 'rake', '< 11'
-else
-  gem 'rake'
-end
+gem 'rake'
 
 group :documentation do
   gem 'yard', '>= 0.8.5.2'

--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     s.metadata["msys2_mingw_dependencies"] = "openssl"
   end
 
-  s.add_development_dependency 'test-unit', '~> 2.0'
+  s.add_development_dependency 'test-unit', '~> 3.2'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.6.3'
 

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -44,7 +44,12 @@ extern "C" {
 		EM_PROTO_SSLv3 = 4,
 		EM_PROTO_TLSv1 = 8,
 		EM_PROTO_TLSv1_1 = 16,
+#ifdef TLS1_3_VERSION
+		EM_PROTO_TLSv1_2 = 32,
+		EM_PROTO_TLSv1_3 = 64
+#else
 		EM_PROTO_TLSv1_2 = 32
+#endif
 	};
 
 	void evma_initialize_library (EMCallback);

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -1569,5 +1569,33 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_const (EmModule, "EM_PROTO_TLSv1",   INT2NUM(EM_PROTO_TLSv1  ));
 	rb_define_const (EmModule, "EM_PROTO_TLSv1_1", INT2NUM(EM_PROTO_TLSv1_1));
 	rb_define_const (EmModule, "EM_PROTO_TLSv1_2", INT2NUM(EM_PROTO_TLSv1_2));
+#ifdef TLS1_3_VERSION
+	rb_define_const (EmModule, "EM_PROTO_TLSv1_3", INT2NUM(EM_PROTO_TLSv1_3));
+#endif
+
+#ifdef OPENSSL_NO_SSL3
+	/* True if SSL3 is not available */
+	rb_define_const (EmModule, "OPENSSL_NO_SSL3", Qtrue);
+	rb_define_const (EmModule, "OPENSSL_NO_SSL2", Qtrue);
+#else
+	rb_define_const (EmModule, "OPENSSL_NO_SSL3", Qfalse);
+#ifdef OPENSSL_NO_SSL2
+	rb_define_const (EmModule, "OPENSSL_NO_SSL2", Qtrue);
+#else
+	rb_define_const (EmModule, "OPENSSL_NO_SSL2", Qfalse);
+#endif
+#endif
+
+  // OpenSSL Build / Runtime/Load versions
+
+	/* Version of OpenSSL that EventMachine was compiled with */
+	rb_define_const(EmModule, "OPENSSL_VERSION", rb_str_new2(OPENSSL_VERSION_TEXT));
+
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
+	/* Version of OpenSSL that EventMachine loaded with */
+	rb_define_const(EmModule, "OPENSSL_LIBRARY_VERSION", rb_str_new2(OpenSSL_version(OPENSSL_VERSION)));
+#else
+	rb_define_const(EmModule, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
+#endif
 }
 

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -180,6 +180,11 @@ SslContext_t::SslContext_t (bool is_server, const std::string &privkeyfile, cons
 		SSL_CTX_set_options (pCtx, SSL_OP_NO_TLSv1_2);
 	#endif
 
+	#ifdef SSL_OP_NO_TLSv1_3
+	if (!(ssl_version & EM_PROTO_TLSv1_3))
+		SSL_CTX_set_options (pCtx, SSL_OP_NO_TLSv1_3);
+	#endif
+
 	#ifdef SSL_MODE_RELEASE_BUFFERS
 	SSL_CTX_set_mode (pCtx, SSL_MODE_RELEASE_BUFFERS);
 	#endif

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -436,6 +436,9 @@ module EventMachine
         protocols_bitmask |= EventMachine::EM_PROTO_TLSv1
         protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_1
         protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_2
+        if EventMachine.const_defined? :EM_PROTO_TLSv1_3
+          protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_3
+        end
       else
         [ssl_version].flatten.each do |p|
           case p.to_s.downcase
@@ -449,6 +452,8 @@ module EventMachine
             protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_1
           when 'tlsv1_2'
             protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_2
+          when 'tlsv1_3'
+            protocols_bitmask |= EventMachine::EM_PROTO_TLSv1_3
           else
             raise("Unrecognized SSL/TLS Protocol: #{p}")
           end

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,8 +1,6 @@
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "tests"
-  t.libs << "lib"
   t.pattern = 'tests/**/test_*.rb'
   t.warning = true
 end

--- a/rakelib/test_pure.rake
+++ b/rakelib/test_pure.rake
@@ -1,8 +1,6 @@
 require 'rake/testtask'
 
 Rake::TestTask.new(:test_pure) do |t|
-  t.libs << 'tests'
-  t.libs << 'lib'
   t.test_files = Dir.glob('tests/**/test_pure*.rb') + Dir.glob('tests/**/test_ssl*.rb')
   t.warning = true
 end

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -4,9 +4,32 @@ require 'test/unit'
 require 'rbconfig'
 require 'socket'
 
-puts "\nEM.library_type #{EM.library_type.to_s.ljust(12)}  EM.ssl? #{EM.ssl?}"
-
 class Test::Unit::TestCase
+
+  # below outputs in to console on load
+  # SSL_AVAIL is used by SSL tests
+  puts "", RUBY_DESCRIPTION
+  puts "\nEM.library_type #{EM.library_type.to_s.ljust(16)} EM.ssl? #{EM.ssl?}"
+  if EM.ssl?
+    require 'openssl'
+    ssl_lib_vers = OpenSSL.const_defined?(:OPENSSL_LIBRARY_VERSION) ?
+      OpenSSL::OPENSSL_LIBRARY_VERSION : 'na'
+    puts "OpenSSL OPENSSL_LIBRARY_VERSION: #{ssl_lib_vers}\n" \
+         "                OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}\n" \
+         "     EM OPENSSL_LIBRARY_VERSION: #{EM::OPENSSL_LIBRARY_VERSION}\n" \
+         "                OPENSSL_VERSION: #{EM::OPENSSL_VERSION}"
+
+    # assumes all 2.x versions include support for TLSv1_2
+    temp = []
+    temp << 'SSLv2' unless EM::OPENSSL_NO_SSL2
+    temp << 'SSLv3' unless EM::OPENSSL_NO_SSL3
+    temp += %w[TLSv1 TLSv1_1 TLSv1_2]
+    temp << 'TLSv1_3' if EM.const_defined? :EM_PROTO_TLSv1_3
+    temp.sort!
+    puts "                      SSL_AVAIL: #{temp.join(' ')}", ""
+    SSL_AVAIL = temp.freeze
+  end
+
   class EMTestTimeout < StandardError ; end
 
   def setup_timeout(timeout = TIMEOUT_INTERVAL)

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -142,6 +142,17 @@ class Test::Unit::TestCase
   # Tests may run slower on windows or Appveyor. YMMV
   TIMEOUT_INTERVAL = windows? ? 0.25 : 0.25
 
+  module EMTestCasePrepend
+    def setup
+      EM.stop while EM.reactor_running?
+    end
+
+    def teardown
+      EM.cleanup_machine
+    end
+  end
+  prepend EMTestCasePrepend
+
   def silent
     backup, $VERBOSE = $VERBOSE, nil
     begin

--- a/tests/test_attach.rb
+++ b/tests/test_attach.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-require 'socket'
+require_relative 'em_test_helper'
 
 class TestAttach < Test::Unit::TestCase
   class EchoServer < EM::Connection

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-require 'socket'
+require_relative 'em_test_helper'
 
 class TestBasic < Test::Unit::TestCase
   def setup

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -38,7 +38,7 @@ class TestBasic < Test::Unit::TestCase
   def test_timer
     assert_nothing_raised do
       EM.run {
-        setup_timeout
+        setup_timeout 0.4
         n = 0
         EM.add_periodic_timer(0.1) {
           n += 1

--- a/tests/test_channel.rb
+++ b/tests/test_channel.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestEMChannel < Test::Unit::TestCase
   def test_channel_subscribe

--- a/tests/test_completion.rb
+++ b/tests/test_completion.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 require 'em/completion'
 
 class TestCompletion < Test::Unit::TestCase

--- a/tests/test_connection_count.rb
+++ b/tests/test_connection_count.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestConnectionCount < Test::Unit::TestCase
   def teardown

--- a/tests/test_connection_write.rb
+++ b/tests/test_connection_write.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestConnectionWrite < Test::Unit::TestCase
 

--- a/tests/test_defer.rb
+++ b/tests/test_defer.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestDefer < Test::Unit::TestCase
 

--- a/tests/test_deferrable.rb
+++ b/tests/test_deferrable.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestDeferrable < Test::Unit::TestCase
   class Later

--- a/tests/test_epoll.rb
+++ b/tests/test_epoll.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-
+require_relative 'em_test_helper'
 
 class TestEpoll < Test::Unit::TestCase
 

--- a/tests/test_error_handler.rb
+++ b/tests/test_error_handler.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestErrorHandler < Test::Unit::TestCase
   def setup

--- a/tests/test_exc.rb
+++ b/tests/test_exc.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSomeExceptions < Test::Unit::TestCase
   class DoomedConnectionError < StandardError

--- a/tests/test_file_watch.rb
+++ b/tests/test_file_watch.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 require 'tempfile'
 
 class TestFileWatch < Test::Unit::TestCase

--- a/tests/test_fork.rb
+++ b/tests/test_fork.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestFork < Test::Unit::TestCase
 

--- a/tests/test_futures.rb
+++ b/tests/test_futures.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestFutures < Test::Unit::TestCase
 

--- a/tests/test_handler_check.rb
+++ b/tests/test_handler_check.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestHandlerCheck < Test::Unit::TestCase
 

--- a/tests/test_hc.rb
+++ b/tests/test_hc.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestHeaderAndContentProtocol < Test::Unit::TestCase
 

--- a/tests/test_httpclient.rb
+++ b/tests/test_httpclient.rb
@@ -135,7 +135,7 @@ class TestHttpClient < Test::Unit::TestCase
       response = nil
       EM.run {
         EM.start_server '127.0.0.1', @port, PostContent
-        setup_timeout(2)
+        setup_timeout 2
         c = silent { EM::P::HttpClient.request(
           :host         => '127.0.0.1',
           :port         => @port,

--- a/tests/test_httpclient.rb
+++ b/tests/test_httpclient.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestHttpClient < Test::Unit::TestCase
 

--- a/tests/test_httpclient2.rb
+++ b/tests/test_httpclient2.rb
@@ -17,7 +17,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   #
   def test_connect
     EM.run {
-      setup_timeout(TIMEOUT_INTERVAL)
+      setup_timeout
       EM.start_server '127.0.0.1', @port, TestServer
       silent do
         EM::P::HttpClient2.connect '127.0.0.1', @port
@@ -29,7 +29,7 @@ class TestHttpClient2 < Test::Unit::TestCase
 
   def test_bad_port
     EM.run {
-      setup_timeout(TIMEOUT_INTERVAL)
+      setup_timeout
       EM.start_server '127.0.0.1', @port, TestServer
       assert_raises( ArgumentError ) {
         silent { EM::P::HttpClient2.connect '127.0.0.1', "xxx" }
@@ -52,8 +52,8 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_get
     content = nil
     EM.run {
-      setup_timeout(TIMEOUT_INTERVAL)
-      http = silent { EM::P::HttpClient2.connect :host => "google.com", :port => 80 }
+      setup_timeout TIMEOUT
+      http = silent { EM::P::HttpClient2.connect :host => "www.google.com", :port => 80 }
       d = http.get "/"
       d.callback {
         content = d.content
@@ -69,7 +69,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def _test_get_multiple
     content = nil
     EM.run {
-      setup_timeout(TIMEOUT_INTERVAL)
+      setup_timeout
       http = silent { EM::P::HttpClient2.connect "www.google.com" }
       d = http.get "/"
       d.callback {
@@ -86,7 +86,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_get_pipeline
     headers, headers2 = nil, nil
     EM.run {
-      setup_timeout(TIMEOUT)
+      setup_timeout TIMEOUT
       http = silent { EM::P::HttpClient2.connect "www.google.com", 80 }
       d = http.get("/")
       d.callback {
@@ -105,7 +105,7 @@ class TestHttpClient2 < Test::Unit::TestCase
 
   def test_authheader
     EM.run {
-      setup_timeout(TIMEOUT)
+      setup_timeout TIMEOUT
       EM.start_server '127.0.0.1', @port, TestServer
       http = silent { EM::P::HttpClient2.connect '127.0.0.1', 18842 }
       d = http.get :url=>"/", :authorization=>"Basic xxx"
@@ -118,7 +118,7 @@ class TestHttpClient2 < Test::Unit::TestCase
     omit("No SSL") unless EM.ssl?
     d = nil
     EM.run {
-      setup_timeout(windows? ? 6 : 1)
+      setup_timeout(windows? ? 6 : TIMEOUT)
       http = silent { EM::P::HttpClient2.connect :host => 'www.google.com', :port => 443, :tls => true }
       d = http.get "/"
       d.callback {EM.stop}

--- a/tests/test_httpclient2.rb
+++ b/tests/test_httpclient2.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestHttpClient2 < Test::Unit::TestCase
   class TestServer < EM::Connection

--- a/tests/test_idle_connection.rb
+++ b/tests/test_idle_connection.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestIdleConnection < Test::Unit::TestCase
   def setup

--- a/tests/test_inactivity_timeout.rb
+++ b/tests/test_inactivity_timeout.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestInactivityTimeout < Test::Unit::TestCase
 

--- a/tests/test_io_streamer.rb
+++ b/tests/test_io_streamer.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 require 'em/io_streamer'
 
 EM::IOStreamer::CHUNK_SIZE = 2

--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestIPv4 < Test::Unit::TestCase
   # Runs a TCP server in the local IPv4 address, connects to it and sends a specific data.

--- a/tests/test_ipv6.rb
+++ b/tests/test_ipv6.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestIPv6 < Test::Unit::TestCase
 

--- a/tests/test_iterator.rb
+++ b/tests/test_iterator.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestIterator < Test::Unit::TestCase
 

--- a/tests/test_kb.rb
+++ b/tests/test_kb.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestKeyboardEvents < Test::Unit::TestCase
 

--- a/tests/test_keepalive.rb
+++ b/tests/test_keepalive.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-require 'socket'
+require_relative 'em_test_helper'
 
 class TestKeepalive < Test::Unit::TestCase
   def setup

--- a/tests/test_line_protocol.rb
+++ b/tests/test_line_protocol.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestLineProtocol < Test::Unit::TestCase
   class LineProtocolTestClass

--- a/tests/test_ltp.rb
+++ b/tests/test_ltp.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestLineAndTextProtocol < Test::Unit::TestCase
 

--- a/tests/test_ltp.rb
+++ b/tests/test_ltp.rb
@@ -39,7 +39,7 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
       EM.start_server( "127.0.0.1", @port, TLP_LineBuffer ) do |c|
         conn = c
       end
-      setup_timeout
+      setup_timeout 0.4
 
       EM.connect "127.0.0.1", @port, StopClient do |c|
         c.send_data "aaa\nbbb\r\nccc\n"
@@ -74,7 +74,7 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
       EM.start_server( "127.0.0.1", @port, TLP_ErrorMessage ) do |c|
         conn = c
       end
-      setup_timeout
+      setup_timeout 0.4
       EM.connect "127.0.0.1", @port, StopClient do |c|
         c.send_data "a" * (16*1024 + 1)
         c.send_data "\n"
@@ -106,7 +106,7 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
     output = ''
     EM.run {
       EM.start_server( "127.0.0.1", @port, LineAndTextTest )
-      setup_timeout
+      setup_timeout 0.4
 
       EM.connect "127.0.0.1", @port, StopClient do |c|
         c.set_receive_data { |data| output << data }
@@ -140,7 +140,7 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
     output = ''
     EM.run {
       EM.start_server( "127.0.0.1", @port, BinaryTextTest )
-      setup_timeout
+      setup_timeout 0.4
 
       EM.connect "127.0.0.1", @port, StopClient do |c|
         c.set_receive_data { |data| output << data }

--- a/tests/test_ltp2.rb
+++ b/tests/test_ltp2.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 # TODO!!! Need tests for overlength headers and text bodies.
 

--- a/tests/test_many_fds.rb
+++ b/tests/test_many_fds.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-require 'socket'
+require_relative 'em_test_helper'
 
 class TestManyFDs < Test::Unit::TestCase
   def setup

--- a/tests/test_next_tick.rb
+++ b/tests/test_next_tick.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestNextTick < Test::Unit::TestCase
 

--- a/tests/test_object_protocol.rb
+++ b/tests/test_object_protocol.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestObjectProtocol < Test::Unit::TestCase
   module Server

--- a/tests/test_pause.rb
+++ b/tests/test_pause.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestPause < Test::Unit::TestCase
   if EM.respond_to? :pause_connection

--- a/tests/test_pending_connect_timeout.rb
+++ b/tests/test_pending_connect_timeout.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestPendingConnectTimeout < Test::Unit::TestCase
 

--- a/tests/test_pending_connect_timeout.rb
+++ b/tests/test_pending_connect_timeout.rb
@@ -31,7 +31,7 @@ class TestPendingConnectTimeout < Test::Unit::TestCase
       end
 
       EM.run {
-        setup_timeout
+        setup_timeout 0.4
         EM.heartbeat_interval = 0.1
         start = EM.current_time
         c = EM.connect('192.0.2.0', 54321, timeout_handler)

--- a/tests/test_pool.rb
+++ b/tests/test_pool.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestPool < Test::Unit::TestCase
   def pool

--- a/tests/test_process_watch.rb
+++ b/tests/test_process_watch.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 if EM.kqueue?
   class TestProcessWatch < Test::Unit::TestCase

--- a/tests/test_processes.rb
+++ b/tests/test_processes.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestProcesses < Test::Unit::TestCase
 

--- a/tests/test_proxy_connection.rb
+++ b/tests/test_proxy_connection.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestProxyConnection < Test::Unit::TestCase
 

--- a/tests/test_pure.rb
+++ b/tests/test_pure.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestPure < Test::Unit::TestCase
 

--- a/tests/test_queue.rb
+++ b/tests/test_queue.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestEMQueue < Test::Unit::TestCase
   def test_queue_push

--- a/tests/test_resolver.rb
+++ b/tests/test_resolver.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestResolver < Test::Unit::TestCase
   def test_nameserver

--- a/tests/test_running.rb
+++ b/tests/test_running.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestRunning < Test::Unit::TestCase
   def test_running

--- a/tests/test_sasl.rb
+++ b/tests/test_sasl.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-
+require_relative 'em_test_helper'
 
 class TestSASL < Test::Unit::TestCase
 

--- a/tests/test_send_file.rb
+++ b/tests/test_send_file.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 require 'tempfile'
 
 class TestSendFile < Test::Unit::TestCase

--- a/tests/test_servers.rb
+++ b/tests/test_servers.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-require 'socket'
+require_relative 'em_test_helper'
 
 class TestServers < Test::Unit::TestCase
 

--- a/tests/test_shutdown_hooks.rb
+++ b/tests/test_shutdown_hooks.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestShutdownHooks < Test::Unit::TestCase
   def test_shutdown_hooks

--- a/tests/test_smtpclient.rb
+++ b/tests/test_smtpclient.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSmtpClient < Test::Unit::TestCase
 

--- a/tests/test_smtpserver.rb
+++ b/tests/test_smtpserver.rb
@@ -1,5 +1,5 @@
+require_relative 'em_test_helper'
 require 'net/smtp'
-require 'em_test_helper'
 
 class TestSmtpServer < Test::Unit::TestCase
 

--- a/tests/test_sock_opt.rb
+++ b/tests/test_sock_opt.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-require 'socket'
+require_relative 'em_test_helper'
 
 class TestSockOpt < Test::Unit::TestCase
   def setup

--- a/tests/test_spawn.rb
+++ b/tests/test_spawn.rb
@@ -1,7 +1,4 @@
-
-require 'em_test_helper'
-
-
+require_relative 'em_test_helper'
 
 class TestSpawn < Test::Unit::TestCase
 

--- a/tests/test_ssl_args.rb
+++ b/tests/test_ssl_args.rb
@@ -1,7 +1,5 @@
-require "test/unit"
+require_relative 'em_test_helper'
 require 'tempfile'
-
-require 'em_test_helper'
 
 module EM
   def self._set_mocks

--- a/tests/test_ssl_dhparam.rb
+++ b/tests/test_ssl_dhparam.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSslDhParam < Test::Unit::TestCase
   def setup

--- a/tests/test_ssl_dhparam.rb
+++ b/tests/test_ssl_dhparam.rb
@@ -8,7 +8,7 @@ class TestSslDhParam < Test::Unit::TestCase
 
   module Client
     def post_init
-      start_tls
+      start_tls(:ssl_version => %w(TLSv1_2))
     end
 
     def ssl_handshake_completed
@@ -24,7 +24,7 @@ class TestSslDhParam < Test::Unit::TestCase
 
   module Server
     def post_init
-      start_tls(:dhparam => $dhparam_file, :cipher_list => "DHE,EDH")
+      start_tls(:dhparam => $dhparam_file, :cipher_list => "DHE,EDH", :ssl_version => %w(TLSv1_2))
     end
 
     def ssl_handshake_completed
@@ -35,7 +35,7 @@ class TestSslDhParam < Test::Unit::TestCase
 
   module NoDhServer
     def post_init
-      start_tls(:cipher_list => "DHE,EDH")
+      start_tls(:cipher_list => "DHE,EDH", :ssl_version => %w(TLSv1_2))
     end
 
     def ssl_handshake_completed

--- a/tests/test_ssl_ecdh_curve.rb
+++ b/tests/test_ssl_ecdh_curve.rb
@@ -3,10 +3,8 @@ require_relative 'em_test_helper'
 class TestSslEcdhCurve < Test::Unit::TestCase
 
   if EM.ssl?
-    require 'openssl'
-    OPENSSL_GT_1_0 = ((OpenSSL::OPENSSL_VERSION[/ (\d+\.\d+\.\d+)[a-z]/,1] || "0.0") >= "1.1") or
-      (OpenSSL.const_defined?(:OPENSSL_LIBRARY_VERSION) ?
-        ((OpenSSL::OPENSSL_LIBRARY_VERSION[/ (\d+\.\d+\.\d+)[a-z]/,1] || "0.0") >= "1.1") : false)
+    SSL_LIB_VERS = EM::OPENSSL_LIBRARY_VERSION[/OpenSSL (\d+\.\d+\.\d+)/, 1]
+      .split('.').map(&:to_i)
   end
 
   module Client
@@ -17,7 +15,7 @@ class TestSslEcdhCurve < Test::Unit::TestCase
     def ssl_handshake_completed
       $client_handshake_completed = true
       $client_cipher_name = get_cipher_name
-      close_connection
+      close_connection unless /TLSv1\.3/i =~ get_cipher_protocol
     end
 
     def unbind
@@ -27,7 +25,11 @@ class TestSslEcdhCurve < Test::Unit::TestCase
 
   module Server
     def post_init
-      start_tls(:ecdh_curve => "prime256v1", :cipher_list => "ECDH")
+      if (SSL_LIB_VERS <=> [1, 1]) == 1
+        start_tls(:cipher_list => "ECDH", :ssl_version => %w(TLSv1_2))
+      else
+        start_tls(:ecdh_curve => "prime256v1", :cipher_list => "ECDH", :ssl_version => %w(TLSv1_2))
+      end
     end
 
     def ssl_handshake_completed
@@ -36,9 +38,21 @@ class TestSslEcdhCurve < Test::Unit::TestCase
     end
   end
 
+  module Server1_3
+    def post_init
+      start_tls(:cipher_list => "ECDH", :ssl_version => %w(TLSv1_3))
+    end
+
+    def ssl_handshake_completed
+      $server_handshake_completed = true
+      $server_cipher_name = get_cipher_name
+      close_connection if /TLSv1\.3/i =~ get_cipher_protocol
+    end
+  end
+
   module NoCurveServer
     def post_init
-      start_tls(:cipher_list => "ECDH")
+      start_tls(:cipher_list => "ECDH", :ssl_version => %w(TLSv1_2))
     end
 
     def ssl_handshake_completed
@@ -50,7 +64,7 @@ class TestSslEcdhCurve < Test::Unit::TestCase
   def test_no_ecdh_curve
     omit("No SSL") unless EM.ssl?
     omit_if(rbx?)
-    omit("OpenSSL 1.1.x (and later) auto selects curve") if OPENSSL_GT_1_0
+    omit("OpenSSL 1.1.x (and later) auto selects curve") if (SSL_LIB_VERS <=> [1, 1]) == 1
 
     $client_handshake_completed, $server_handshake_completed = false, false
 
@@ -85,5 +99,27 @@ class TestSslEcdhCurve < Test::Unit::TestCase
     assert_match(/^(AECDH|ECDHE)/, $client_cipher_name)
   end
 
+  def test_ecdh_curve_tlsv1_3
+    omit("No SSL") unless EM.ssl?
+    omit_if(EM.library_type == :pure_ruby && RUBY_VERSION < "2.3.0")
+    omit_if(rbx?)
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
 
+    $client_handshake_completed, $server_handshake_completed = false, false
+    $server_cipher_name, $client_cipher_name = nil, nil
+
+    EM.run {
+      EM.start_server("127.0.0.1", 16784, Server1_3)
+      EM.connect("127.0.0.1", 16784, Client)
+    }
+
+    assert($client_handshake_completed)
+    assert($server_handshake_completed)
+
+    assert($client_cipher_name.length > 0)
+    assert_equal($client_cipher_name, $server_cipher_name)
+    # see https://wiki.openssl.org/index.php/TLS1.3#Ciphersuites
+    # may depend on OpenSSL build options
+    assert_equal("TLS_AES_256_GCM_SHA384", $client_cipher_name)
+  end
 end

--- a/tests/test_ssl_ecdh_curve.rb
+++ b/tests/test_ssl_ecdh_curve.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSslEcdhCurve < Test::Unit::TestCase
 

--- a/tests/test_ssl_extensions.rb
+++ b/tests/test_ssl_extensions.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-
+require_relative 'em_test_helper'
 require 'socket'
 require 'openssl'
 

--- a/tests/test_ssl_extensions.rb
+++ b/tests/test_ssl_extensions.rb
@@ -1,47 +1,59 @@
 require_relative 'em_test_helper'
-require 'socket'
-require 'openssl'
 
 if EM.ssl?
   class TestSslExtensions < Test::Unit::TestCase
 
+    IP, PORT = "127.0.0.1", 16784
+  
     module Client
-      def ssl_handshake_completed
-        $client_handshake_completed = true
-        close_connection
-      end
-
-      def unbind
-        EM.stop_event_loop
+      def self.ssl_vers=(val = nil)
+        @@ssl_vers = val
       end
 
       def post_init
-        start_tls(:ssl_version => :tlsv1, :sni_hostname => 'example.com')
+        start_tls(:sni_hostname => 'example.com', :ssl_version => @@ssl_vers)
       end
     end
 
     module Server
-      def ssl_handshake_completed
-        $server_handshake_completed = true
-        $server_sni_hostname = get_sni_hostname
-      end
+      @@handshake_completed = false
+      @@sni_hostname = 'Not set'
+      
+      def self.handshake_completed? ; !!@@handshake_completed end
+      def self.sni_hostname         ;   @@sni_hostname        end
 
       def post_init
-        start_tls(:ssl_version => :TLSv1)
+        start_tls
+      end
+
+      def ssl_handshake_completed
+        @@handshake_completed = true
+        @@sni_hostname = get_sni_hostname
       end
     end
 
-    def test_tlsext_sni_hostname
-      $server_handshake_completed = false
-
+    def client_server(client = nil)
       EM.run do
-        EM.start_server("127.0.0.1", 16784, Server)
-        EM.connect("127.0.0.1", 16784, Client)
+        Client.ssl_vers = client
+        EM.start_server IP, PORT, Server
+        EM.connect IP, PORT, Client
+        EM.add_timer(0.3) { EM.stop_event_loop }
       end
-
-      assert($server_handshake_completed)
-      assert_equal('example.com', $server_sni_hostname)
     end
+    
+    def test_tlsext_sni_hostname_1_2
+      client_server %w(TLSv1_2)
+      assert Server.handshake_completed?
+      assert_equal 'example.com', Server.sni_hostname
+    end
+    
+    def test_tlsext_sni_hostname_1_3
+      omit("TLSv1_3 is unavailable") unless SSL_AVAIL.include? "tlsv1_3"
+      client_server %w(TLSv1_3)
+      assert Server.handshake_completed?
+      assert_equal 'example.com', Server.sni_hostname
+    end
+    
   end
 else
   warn "EM built without SSL support, skipping tests in #{__FILE__}"

--- a/tests/test_ssl_methods.rb
+++ b/tests/test_ssl_methods.rb
@@ -13,6 +13,7 @@ class TestSSLMethods < Test::Unit::TestCase
       $server_cipher_bits = get_cipher_bits
       $server_cipher_name = get_cipher_name
       $server_cipher_protocol = get_cipher_protocol
+      EM.stop_event_loop if /TLSv1\.3/ =~ get_cipher_protocol
     end
   end
 
@@ -27,7 +28,7 @@ class TestSSLMethods < Test::Unit::TestCase
       $client_cipher_bits = get_cipher_bits
       $client_cipher_name = get_cipher_name
       $client_cipher_protocol = get_cipher_protocol
-      EM.stop_event_loop
+      EM.stop_event_loop if /TLSv1\.3/ !~ get_cipher_protocol
     end
   end
 

--- a/tests/test_ssl_methods.rb
+++ b/tests/test_ssl_methods.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSSLMethods < Test::Unit::TestCase
 

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -5,21 +5,6 @@ require 'openssl'
 if EM.ssl?
   class TestSslProtocols < Test::Unit::TestCase
 
-    if ::OpenSSL::VERSION >= "2.1"
-      # Assume no SSLv3 in OpenSSL, OpenSSL::SSL::SSLContext::METHODS deprecated
-      SSL_AVAIL = ["tlsv1", "tlsv1_1", "tlsv1_2"]
-    else
-      # Equal to base METHODS, downcased, like ["tlsv1, "tlsv1_1", "tlsv1_2"]
-      SSL_AVAIL = ::OpenSSL::SSL::SSLContext::METHODS.select { |i| i =~ /[^\d]\d\z/ }.map { |i| i.to_s.downcase }
-    end
-
-    libr_vers =  OpenSSL.const_defined?(:OPENSSL_LIBRARY_VERSION) ?
-      OpenSSL::OPENSSL_VERSION : 'na'
-
-    puts "OPENSSL_LIBRARY_VERSION: #{libr_vers}\n" \
-         "        OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}\n" \
-         "              SSL_AVAIL: #{SSL_AVAIL.sort.join(' ')}"
-
     module Client
       def ssl_handshake_completed
         $client_handshake_completed = true
@@ -40,7 +25,7 @@ if EM.ssl?
     module ClientAny
       include Client
       def post_init
-        start_tls(:ssl_version => SSL_AVAIL)
+        start_tls(:ssl_version => TestSslProtocols::SSL_AVAIL)
       end
     end
 
@@ -89,7 +74,7 @@ if EM.ssl?
     module ServerAny
       include Server
       def post_init
-        start_tls(:ssl_version => SSL_AVAIL)
+        start_tls(:ssl_version => TestSslProtocols::SSL_AVAIL)
       end
     end
 
@@ -117,7 +102,7 @@ if EM.ssl?
     end
 
     def test_any_to_v3
-      omit("SSLv3 is (correctly) unavailable") unless SSL_AVAIL.include? "sslv3"
+      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
       $client_handshake_completed, $server_handshake_completed = false, false
       EM.run do
         EM.start_server("127.0.0.1", 16784, ServerSSLv3)
@@ -129,7 +114,7 @@ if EM.ssl?
     end
 
     def test_any_to_tlsv1_2
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "tlsv1_2"
+      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
       $client_handshake_completed, $server_handshake_completed = false, false
       EM.run do
         EM.start_server("127.0.0.1", 16784, ServerTLSv1_2)
@@ -152,7 +137,7 @@ if EM.ssl?
     end
 
     def test_v3_to_any
-      omit("SSLv3 is (correctly) unavailable") unless SSL_AVAIL.include? "sslv3"
+      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
       $client_handshake_completed, $server_handshake_completed = false, false
       EM.run do
         EM.start_server("127.0.0.1", 16784, ServerAny)
@@ -164,7 +149,7 @@ if EM.ssl?
     end
 
     def test_tlsv1_2_to_any
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "tlsv1_2"
+      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
       $client_handshake_completed, $server_handshake_completed = false, false
       EM.run do
         EM.start_server("127.0.0.1", 16784, ServerAny)
@@ -176,7 +161,7 @@ if EM.ssl?
     end
 
     def test_v3_to_v3
-      omit("SSLv3 is (correctly) unavailable") unless SSL_AVAIL.include? "sslv3"
+      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
       $client_handshake_completed, $server_handshake_completed = false, false
       EM.run do
         EM.start_server("127.0.0.1", 16784, ServerSSLv3)
@@ -188,7 +173,7 @@ if EM.ssl?
     end
 
     def test_tlsv1_2_to_tlsv1_2
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "tlsv1_2"
+      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
       $client_handshake_completed, $server_handshake_completed = false, false
       EM.run do
         EM.start_server("127.0.0.1", 16784, ServerTLSv1_2)
@@ -245,7 +230,7 @@ if EM.ssl?
 
     module ServerAnyStopAfterHandshake
       def post_init
-        start_tls(:ssl_version => SSL_AVAIL)
+        start_tls(:ssl_version => TestSslProtocols::SSL_AVAIL)
       end
 
       def ssl_handshake_completed
@@ -255,7 +240,7 @@ if EM.ssl?
     end
 
     def test_v3_with_external_client
-      omit("SSLv3 is (correctly) unavailable") unless SSL_AVAIL.include? "sslv3"
+      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
       $server_handshake_completed = false
       EM.run do
         setup_timeout(2)
@@ -276,7 +261,7 @@ if EM.ssl?
 
     # Fixed Server
     def test_tlsv1_2_with_external_client
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "tlsv1_2"
+      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
       $server_handshake_completed = false
       EM.run do
         setup_timeout(2)
@@ -284,7 +269,7 @@ if EM.ssl?
         EM.defer do
           sock = TCPSocket.new("127.0.0.1", 16784)
           ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :SSLv23_client
+          ctx.ssl_version = :SSLv23
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
           ssl.connect
           ssl.close rescue nil
@@ -297,7 +282,7 @@ if EM.ssl?
 
     # Fixed Client
     def test_any_with_external_client_tlsv1_2
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "tlsv1_2"
+      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
       $server_handshake_completed = false
       EM.run do
         setup_timeout(2)
@@ -305,7 +290,7 @@ if EM.ssl?
         EM.defer do
           sock = TCPSocket.new("127.0.0.1", 16784)
           ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :TLSv1_2_client
+          ctx.ssl_version = :TLSv1_2
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
           ssl.connect
           ssl.close rescue nil
@@ -318,7 +303,7 @@ if EM.ssl?
 
     # Refuse a client?
     def test_tlsv1_2_required_with_external_client
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "tlsv1_2"
+      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
       $server_handshake_completed = false
       EM.run do
         n = 0
@@ -330,7 +315,7 @@ if EM.ssl?
         EM.defer do
           sock = TCPSocket.new("127.0.0.1", 16784)
           ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :TLSv1_client
+          ctx.ssl_version = :TLSv1
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
           assert_raise(OpenSSL::SSL::SSLError) { ssl.connect }
           ssl.close rescue nil

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -1,5 +1,4 @@
-require 'em_test_helper'
-
+require_relative 'em_test_helper'
 require 'socket'
 require 'openssl'
 

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -1,321 +1,224 @@
 require_relative 'em_test_helper'
-require 'socket'
-require 'openssl'
 
 if EM.ssl?
+
   class TestSslProtocols < Test::Unit::TestCase
 
+    IP, PORT = "127.0.0.1", 16784
+    RUBY_SSL_GE_2_1 = OpenSSL::VERSION >= '2.1'
+
     module Client
-      def ssl_handshake_completed
-        $client_handshake_completed = true
-        close_connection
+      @@handshake_completed = false
+
+      def self.ssl_vers=(val = nil)
+        @@ssl_vers = val
       end
 
-      def unbind
-        EM.stop_event_loop
+      def self.handshake_completed?
+        @@handshake_completed
+      end
+
+      def post_init
+        @@handshake_completed = false
+        if @@ssl_vers
+          start_tls(:ssl_version => @@ssl_vers)
+        else
+          start_tls
+        end
+      end
+
+      def ssl_handshake_completed
+        @@handshake_completed = true
       end
     end
 
     module Server
+      @@handshake_completed = false
+
+      def self.ssl_vers=(val = nil)
+        @@ssl_vers = val
+      end
+
+      def self.handshake_completed? ; @@handshake_completed end
+
+      def post_init
+        @@handshake_completed = false
+        if @@ssl_vers
+          start_tls(:ssl_version => @@ssl_vers)
+        else
+          start_tls
+        end
+      end
+
       def ssl_handshake_completed
-        $server_handshake_completed = true
+        @@handshake_completed = true
       end
     end
 
-    module ClientAny
-      include Client
-      def post_init
-        start_tls(:ssl_version => TestSslProtocols::SSL_AVAIL)
-      end
-    end
-
-    module ClientDefault
-      include Client
-      def post_init
-        start_tls
-      end
-    end
-
-    module ClientSSLv3
-      include Client
-      def post_init
-        start_tls(:ssl_version => %w(SSLv3))
-      end
-    end
-
-    module ServerSSLv3
-      include Server
-      def post_init
-        start_tls(:ssl_version => %w(SSLv3))
-      end
-    end
-
-    module ClientTLSv1_2
-      include Client
-      def post_init
-        start_tls(:ssl_version => %w(TLSv1_2))
-      end
-    end
-
-    module ServerTLSv1_2
-      include Server
-      def post_init
-        start_tls(:ssl_version => %w(TLSv1_2))
-      end
-    end
-
-    module ServerTLSv1CaseInsensitive
-      include Server
-      def post_init
-        start_tls(:ssl_version => %w(tlsv1))
-      end
-    end
-
-    module ServerAny
-      include Server
-      def post_init
-        start_tls(:ssl_version => TestSslProtocols::SSL_AVAIL)
-      end
-    end
-
-    module ServerDefault
-      include Server
-      def post_init
-        start_tls
-      end
-    end
-
-    module InvalidProtocol
-      include Client
-      def post_init
-        start_tls(:ssl_version => %w(tlsv1 badinput))
+    def client_server(client = nil, server = nil)
+      EM.run do
+        Client.ssl_vers, Server.ssl_vers = client, server
+        EM.start_server IP, PORT, Server
+        EM.connect IP, PORT, Client
+        EM.add_timer(0.3) { EM.stop_event_loop }
       end
     end
 
     def test_invalid_ssl_version
       assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do
-        EM.run do
-          EM.start_server("127.0.0.1", 16784, InvalidProtocol)
-          EM.connect("127.0.0.1", 16784, InvalidProtocol)
-        end
+        client_server %w(tlsv1 badinput), %w(tlsv1 badinput)
       end
     end
 
     def test_any_to_v3
       omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerSSLv3)
-        EM.connect("127.0.0.1", 16784, ClientAny)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      client_server SSL_AVAIL, %w(SSLv3)
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_any_to_tlsv1_2
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerTLSv1_2)
-        EM.connect("127.0.0.1", 16784, ClientAny)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      client_server SSL_AVAIL, %w(TLSv1_2)
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_case_insensitivity
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerTLSv1CaseInsensitive)
-        EM.connect("127.0.0.1", 16784, ClientAny)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      lower_case = SSL_AVAIL.map { |p| p.downcase }
+      client_server %w(tlsv1), lower_case
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_v3_to_any
       omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerAny)
-        EM.connect("127.0.0.1", 16784, ClientSSLv3)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      client_server %w(SSLv3), SSL_AVAIL
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_tlsv1_2_to_any
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerAny)
-        EM.connect("127.0.0.1", 16784, ClientTLSv1_2)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      client_server %w(TLSv1_2), SSL_AVAIL
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_v3_to_v3
       omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerSSLv3)
-        EM.connect("127.0.0.1", 16784, ClientSSLv3)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      client_server %w(SSLv3), %w(SSLv3)
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_tlsv1_2_to_tlsv1_2
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerTLSv1_2)
-        EM.connect("127.0.0.1", 16784, ClientTLSv1_2)
-      end
+      client_server %w(TLSv1_2), %w(TLSv1_2)
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
+    end
 
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+    def test_tlsv1_3_to_tlsv1_3
+      omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+      client_server %w(TLSv1_3), %w(TLSv1_3)
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_any_to_any
-      $client_handshake_completed, $server_handshake_completed = false, false
-      EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerAny)
-        EM.connect("127.0.0.1", 16784, ClientAny)
-      end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
+      client_server SSL_AVAIL, SSL_AVAIL
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
     end
 
     def test_default_to_default
-      $client_handshake_completed, $server_handshake_completed = false, false
+      client_server
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
+    end
+
+    module ServerStopAfterHandshake
+      def self.ssl_vers=(val)
+        @@ssl_vers = val
+      end
+
+      def self.handshake_completed? ; @@handshake_completed end
+
+      def post_init
+        @@handshake_completed = false
+        start_tls(:ssl_version => @@ssl_vers)
+      end
+
+      def ssl_handshake_completed
+        @@handshake_completed = true
+        EM.stop_event_loop
+      end
+    end
+
+    def external_client(ext_min, ext_max, ext_ssl, server)
       EM.run do
-        EM.start_server("127.0.0.1", 16784, ServerDefault)
-        EM.connect("127.0.0.1", 16784, ClientDefault)
+        setup_timeout(2)
+        ServerStopAfterHandshake.ssl_vers = server
+        EM.start_server(IP, PORT, ServerStopAfterHandshake)
+        EM.defer do
+          sock = TCPSocket.new(IP, PORT)
+          ctx = OpenSSL::SSL::SSLContext.new
+          if RUBY_SSL_GE_2_1
+            ctx.min_version = ext_min if ext_min
+            ctx.max_version = ext_max if ext_max
+          else
+            ctx.ssl_version = ext_ssl
+          end
+          ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+          ssl.connect
+          ssl.close rescue nil
+          sock.close rescue nil
+        end
       end
-
-      assert($client_handshake_completed)
-      assert($server_handshake_completed)
-    end
-
-    module ServerV3StopAfterHandshake
-      def post_init
-        start_tls(:ssl_version => %w(SSLv3))
-      end
-
-      def ssl_handshake_completed
-        $server_handshake_completed = true
-        EM.stop_event_loop
-      end
-    end
-
-    module ServerTLSv1_2StopAfterHandshake
-      def post_init
-        start_tls(:ssl_version => %w(TLSv1_2))
-      end
-
-      def ssl_handshake_completed
-        $server_handshake_completed = true
-        EM.stop_event_loop
-      end
-    end
-
-    module ServerAnyStopAfterHandshake
-      def post_init
-        start_tls(:ssl_version => TestSslProtocols::SSL_AVAIL)
-      end
-
-      def ssl_handshake_completed
-        $server_handshake_completed = true
-        EM.stop_event_loop
-      end
+      assert ServerStopAfterHandshake.handshake_completed?
     end
 
     def test_v3_with_external_client
       omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      $server_handshake_completed = false
-      EM.run do
-        setup_timeout(2)
-        EM.start_server("127.0.0.1", 16784, ServerV3StopAfterHandshake)
-        EM.defer do
-          sock = TCPSocket.new("127.0.0.1", 16784)
-          ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :SSLv3_client
-          ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-          ssl.connect
-          ssl.close rescue nil
-          sock.close rescue nil
-        end
-      end
-
-      assert($server_handshake_completed)
+      external_client nil, nil, :SSLv3_client, %w(SSLv3)
     end
 
     # Fixed Server
     def test_tlsv1_2_with_external_client
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
-      $server_handshake_completed = false
-      EM.run do
-        setup_timeout(2)
-        EM.start_server("127.0.0.1", 16784, ServerTLSv1_2StopAfterHandshake)
-        EM.defer do
-          sock = TCPSocket.new("127.0.0.1", 16784)
-          ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :SSLv23
-          ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-          ssl.connect
-          ssl.close rescue nil
-          sock.close rescue nil
-        end
-      end
+      external_client nil, nil, :SSLv23_client, %w(TLSv1_2)
+    end
 
-      assert($server_handshake_completed)
+    def test_tlsv1_3_with_external_client
+      omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+      external_client nil, nil, :SSLv23_client, %w(TLSv1_3)
     end
 
     # Fixed Client
     def test_any_with_external_client_tlsv1_2
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
-      $server_handshake_completed = false
-      EM.run do
-        setup_timeout(2)
-        EM.start_server("127.0.0.1", 16784, ServerAnyStopAfterHandshake)
-        EM.defer do
-          sock = TCPSocket.new("127.0.0.1", 16784)
-          ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :TLSv1_2
-          ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-          ssl.connect
-          ssl.close rescue nil
-          sock.close rescue nil
-        end
-      end
+      external_client :TLS1_2, :TLS1_2, :TLSv1_2_client, SSL_AVAIL
+    end
 
-      assert($server_handshake_completed)
+    def test_any_with_external_client_tlsv1_3
+      omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+      external_client :TLS1_3, :TLS1_3, :TLSv1_2_client, SSL_AVAIL
     end
 
     # Refuse a client?
     def test_tlsv1_2_required_with_external_client
-      omit("TLSv1_2 is unavailable") unless SSL_AVAIL.include? "TLSv1_2"
-      $server_handshake_completed = false
       EM.run do
         n = 0
         EM.add_periodic_timer(0.5) do
           n += 1
           (EM.stop rescue nil) if n == 2
         end
-        EM.start_server("127.0.0.1", 16784, ServerTLSv1_2StopAfterHandshake)
+        ServerStopAfterHandshake.ssl_vers = %w(TLSv1_2)
+        EM.start_server(IP, PORT, ServerStopAfterHandshake)
         EM.defer do
-          sock = TCPSocket.new("127.0.0.1", 16784)
+          sock = TCPSocket.new(IP, PORT)
           ctx = OpenSSL::SSL::SSLContext.new
-          ctx.ssl_version = :TLSv1
+          if RUBY_SSL_GE_2_1
+            ctx.max_version = :TLS1_1
+          else
+            ctx.ssl_version = :TLSv1_client
+          end
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
           assert_raise(OpenSSL::SSL::SSLError) { ssl.connect }
           ssl.close rescue nil
@@ -323,8 +226,7 @@ if EM.ssl?
           EM.stop rescue nil
         end
       end
-
-      assert(!$server_handshake_completed)
+      assert !ServerStopAfterHandshake.handshake_completed?
     end
   end
 else

--- a/tests/test_ssl_verify.rb
+++ b/tests/test_ssl_verify.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSslVerify < Test::Unit::TestCase
   def setup

--- a/tests/test_stomp.rb
+++ b/tests/test_stomp.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestStomp < Test::Unit::TestCase
   CONTENT_LENGTH_REGEX = /^content-length: (\d+)$/

--- a/tests/test_system.rb
+++ b/tests/test_system.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestSystem < Test::Unit::TestCase
   def setup

--- a/tests/test_threaded_resource.rb
+++ b/tests/test_threaded_resource.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestThreadedResource < Test::Unit::TestCase
   def object

--- a/tests/test_tick_loop.rb
+++ b/tests/test_tick_loop.rb
@@ -1,5 +1,4 @@
-require "test/unit"
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestEmTickLoop < Test::Unit::TestCase
   def test_em_tick_loop

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestTimers < Test::Unit::TestCase
 

--- a/tests/test_ud.rb
+++ b/tests/test_ud.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestUserDefinedEvents < Test::Unit::TestCase
 

--- a/tests/test_unbind_reason.rb
+++ b/tests/test_unbind_reason.rb
@@ -1,4 +1,4 @@
-require 'em_test_helper'
+require_relative 'em_test_helper'
 
 class TestUnbindReason < Test::Unit::TestCase
 


### PR DESCRIPTION
1. Updates tests and code for OpenSSL 1.1.1
2. Adds EM::OPENSSL_LIBRARY_VERSION and EM::OPENSSL_VERSION constants
3. Various updates to Travis for Ruby 2.6, change to xenial, adds MacOS, etc