### PR TITLE
Add test/em_ssl_handlers.rb

### DIFF
--- a/tests/em_ssl_handlers.rb
+++ b/tests/em_ssl_handlers.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+##
+# EMSSLHandlers has two classes, `Client` and `Server`, and one method,
+# `client_server`, which is a wrapper around
+#
+#    EM.run do
+#      EM.start_server IP, PORT, s_hndlr, server
+#      EM.connect IP, PORT, c_hndlr, client
+#    end  
+#
+# It also passes parameters to the `start_tls` call within the `post_init`
+# callbacks of Client and Server.
+#
+# Client and Server have most standard callbacks and many 'get_*' function values
+# as attributes.
+#
+# `Client` has a `:client_unbind` parameter, which when set to true, calls
+# `EM.stop_event_loop` in the `unbind` callback.
+# 
+# `Server` has two additional paramters.
+#
+# `:ssl_verify_result`, which is normally set to true/false for the
+# `ssl_verify_peer` return value.  If it is set to a String starting with "|RAISE|",
+# the remaing string will be raised.
+# 
+# `:stop_after_handshake`, when set to true, will close the connection and then
+# call `EM.stop_event_loop`.
+#
+module EMSSLHandlers
+
+  IP, PORT = "127.0.0.1", 16784
+
+  # is OpenSSL version >= 1.1.0
+  IS_SSL_GE_1_1 = (EM::OPENSSL_LIBRARY_VERSION[/OpenSSL (\d+\.\d+\.\d+)/, 1]
+    .split('.').map(&:to_i) <=> [1,1]) == 1
+
+  # common start_tls parameters
+  SSL_3   = { ssl_version: %w(SSLv3)   }
+  TLS_1_2 = { ssl_version: %w(TLSv1_2) }
+  TLS_1_3 = { ssl_version: %w(TLSv1_3) }
+  TLS_ALL = { ssl_version: Test::Unit::TestCase::SSL_AVAIL }
+
+  module Client
+    def initialize(tls = nil)
+      @@tls = tls ? tls.dup : tls
+      @@handshake_completed = false
+      @@cert_value      = nil
+      @@cipher_bits     = nil
+      @@cipher_name     = nil
+      @@cipher_protocol = nil
+      @@client_unbind = @@tls ? @@tls.delete(:client_unbind) : nil
+    end
+
+    def self.cert_value           ;   @@cert_value          end
+    def self.cipher_bits          ;   @@cipher_bits         end
+    def self.cipher_name          ;   @@cipher_name         end
+    def self.cipher_protocol      ;   @@cipher_protocol     end
+    def self.handshake_completed? ; !!@@handshake_completed end
+
+    def post_init
+      if @@tls
+        start_tls @@tls
+      else
+        start_tls
+      end
+    end
+
+    def ssl_handshake_completed
+      @@handshake_completed = true
+      @@cert_value      = get_peer_cert
+      @@cipher_bits     = get_cipher_bits
+      @@cipher_name     = get_cipher_name
+      @@cipher_protocol = get_cipher_protocol
+
+      if "TLSv1.3" != @@cipher_protocol
+        close_connection
+        EM.stop_event_loop
+      end
+    end
+
+    def unbind
+      EM.stop_event_loop if @@client_unbind
+    end
+  end
+
+  module Server
+    def initialize(tls = nil)
+      @@tls = tls ? tls.dup : tls
+      @@handshake_completed = false
+      @@cert_value      = nil
+      @@cipher_bits     = nil
+      @@cipher_name     = nil
+      @@cipher_protocol = nil
+      @@sni_hostname = "not set"
+      @@ssl_verify_result    = @@tls ? @@tls.delete(:ssl_verify_result)    : nil
+      @@stop_after_handshake = @@tls ? @@tls.delete(:stop_after_handshake) : nil
+    end
+
+    def self.cert                 ;   @@cert                end
+    def self.cert_value           ;   @@cert_value          end
+    def self.cipher_bits          ;   @@cipher_bits         end
+    def self.cipher_name          ;   @@cipher_name         end
+    def self.cipher_protocol      ;   @@cipher_protocol     end
+    def self.handshake_completed? ; !!@@handshake_completed end
+    def self.sni_hostname         ;   @@sni_hostname        end
+
+    def post_init
+      if @@tls
+        start_tls @@tls
+      else
+        start_tls
+      end
+    end
+
+    def ssl_verify_peer(cert)
+      @@cert = cert
+      if @@ssl_verify_result.is_a?(String) && @@ssl_verify_result.start_with?("|RAISE|")
+        raise @@ssl_verify_result.sub('|RAISE|', '')
+      else
+        @@ssl_verify_result
+      end
+    end
+    
+    def ssl_handshake_completed
+      @@handshake_completed = true
+      @@cert_value      = get_peer_cert
+      @@cipher_bits     = get_cipher_bits
+      @@cipher_name     = get_cipher_name
+      @@cipher_protocol = get_cipher_protocol
+
+      @@sni_hostname    = get_sni_hostname
+      if ("TLSv1.3" == @@cipher_protocol) || @@stop_after_handshake
+        close_connection
+        EM.stop_event_loop
+      end
+    end
+
+    def unbind
+      EM.stop_event_loop unless @@handshake_completed
+    end
+  end
+
+  def client_server(c_hndlr = Client, s_hndlr = Server, client: nil, server: nil)
+    EM.run do
+      EM.start_server IP, PORT, s_hndlr, server
+      EM.connect IP, PORT, c_hndlr, client
+      # fail safe stop
+      EM.add_timer(3.0) { EM.stop_event_loop }
+    end
+  end
+end if EM.ssl?

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -1,12 +1,16 @@
 require 'em/pure_ruby' if ENV['EM_PURE_RUBY']
 require 'eventmachine'
-require 'test/unit'
 require 'rbconfig'
 require 'socket'
 
+# verbose fun is to stop warnings when loading test-unit 3.2.9 in trunk
+verbose, $VERBOSE = $VERBOSE, nil
+require 'test/unit'
+$VERBOSE = verbose
+
 class Test::Unit::TestCase
 
-  # below outputs in to console on load
+  # below outputs to console on load
   # SSL_AVAIL is used by SSL tests
   puts "", RUBY_DESCRIPTION
   puts "\nEM.library_type #{EM.library_type.to_s.ljust(16)} EM.ssl? #{EM.ssl?}"
@@ -28,6 +32,9 @@ class Test::Unit::TestCase
     temp.sort!
     puts "                      SSL_AVAIL: #{temp.join(' ')}", ""
     SSL_AVAIL = temp.freeze
+  else
+    puts "\nEventMachine is not built with OpenSSL support, skipping tests in",
+         "files tests/test_ssl_*.rb"
   end
 
   class EMTestTimeout < StandardError ; end
@@ -184,5 +191,4 @@ class Test::Unit::TestCase
   ensure
     Socket.do_not_reverse_lookup = orig
   end
-
 end

--- a/tests/test_io_streamer.rb
+++ b/tests/test_io_streamer.rb
@@ -1,13 +1,21 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 require 'em/io_streamer'
 
-EM::IOStreamer::CHUNK_SIZE = 2
+# below to stop 'already initialized constant' warning
+EM::IOStreamer.__send__ :remove_const, :CHUNK_SIZE
+EM::IOStreamer.const_set :CHUNK_SIZE, 2
 
 class TestIOStreamer < Test::Unit::TestCase
+
   class StreamServer < EM::Connection
-    TEST_STRING = 'this is a test'.freeze
+    def initialize(sent)
+      @sent = sent
+    end
+
     def post_init
-      io = StringIO.new(TEST_STRING)
+      io = StringIO.new @sent
       EM::IOStreamer.new(self, io).callback { close_connection_after_writing }
     end
   end
@@ -16,21 +24,24 @@ class TestIOStreamer < Test::Unit::TestCase
     def initialize(received)
       @received = received
     end
+
     def receive_data data
       @received << data
     end
+
     def unbind
       EM.stop
     end
   end
 
   def test_io_stream
-    received = ''
+    sent = 'this is a test'
+    received = ''.dup
     EM.run do
       port = next_port
-      EM.start_server '127.0.0.1', port, StreamServer
+      EM.start_server '127.0.0.1', port, StreamServer, sent
       EM.connect '127.0.0.1', port, StreamClient, received
     end
-    assert_equal(StreamServer::TEST_STRING, received)
+    assert_equal sent, received
   end
 end

--- a/tests/test_ssl_args.rb
+++ b/tests/test_ssl_args.rb
@@ -3,7 +3,7 @@
 require_relative 'em_test_helper'
 require 'tempfile'
 
-class TestSslArgs < Test::Unit::TestCase
+class TestSSLArgs < Test::Unit::TestCase
 
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers

--- a/tests/test_ssl_args.rb
+++ b/tests/test_ssl_args.rb
@@ -1,76 +1,41 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 require 'tempfile'
 
-module EM
-  def self._set_mocks
-    class <<self
-      alias set_tls_parms_old set_tls_parms
-      alias start_tls_old start_tls
-      begin
-        old, $VERBOSE = $VERBOSE, nil
-        def set_tls_parms *args; end
-        def start_tls *args; end
-      ensure
-        $VERBOSE = old
-      end
-    end
-  end
-
-  def self._clear_mocks
-    class <<self
-      begin
-        old, $VERBOSE = $VERBOSE, nil
-        alias set_tls_parms set_tls_parms_old
-        alias start_tls start_tls_old
-      ensure
-        $VERBOSE = old
-      end
-    end
-  end
-end
-
-  
-
 class TestSslArgs < Test::Unit::TestCase
-  def setup
-    EM._set_mocks
-  end
-  
-  def teardown
-    EM._clear_mocks
-  end
-  
+
+  require_relative 'em_ssl_handlers'
+  include EMSSLHandlers
+
   def test_tls_params_file_doesnt_exist
     priv_file, cert_file = 'foo_priv_key', 'bar_cert_file'
     [priv_file, cert_file].all? do |f|
       assert(!File.exist?(f), "Cert file #{f} seems to exist, and should not for the tests")
     end
-    
-    # associate_callback_target is a pain! (build!)
-    conn = EM::Connection.new('foo')
-    
-    assert_raises(EM::FileNotFoundException) do
-      conn.start_tls(:private_key_file => priv_file)
+
+    assert_raises EM::FileNotFoundException do
+      client_server client: { private_key_file: priv_file }
     end
-    assert_raises(EM::FileNotFoundException) do
-      conn.start_tls(:cert_chain_file => cert_file)
+
+    assert_raises EM::FileNotFoundException do
+      client_server client: { cert_chain_file: cert_file }
     end
-    assert_raises(EM::FileNotFoundException) do
-      conn.start_tls(:private_key_file => priv_file, :cert_chain_file => cert_file)
+
+    assert_raises EM::FileNotFoundException do
+      client_server client: { private_key_file: priv_file, cert_chain_file: cert_file }
     end
   end
-  
-  def test_tls_params_file_does_exist
-    priv_file = Tempfile.new('em_test')
-    cert_file = Tempfile.new('em_test')
-    priv_file_path = priv_file.path
-    cert_file_path = cert_file.path
-    conn = EM::Connection.new('foo')
-    params = {:private_key_file => priv_file_path, :cert_chain_file => cert_file_path}
+
+  def _test_tls_params_file_improper
+    priv_file_path = Tempfile.new('em_test').path
+    cert_file_path = Tempfile.new('em_test').path
+    params = { private_key_file: priv_file_path,
+                cert_chain_file: cert_file_path }
     begin
-      conn.start_tls params
+      client_server client: params
     rescue Object
-      assert(false, 'should not have raised an exception')
+      assert false, 'should not have raised an exception'
     end
   end
 end if EM.ssl?

--- a/tests/test_ssl_dhparam.rb
+++ b/tests/test_ssl_dhparam.rb
@@ -2,7 +2,7 @@
 
 require_relative 'em_test_helper'
 
-class TestSslDhParam < Test::Unit::TestCase
+class TestSSLDhParam < Test::Unit::TestCase
 
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers

--- a/tests/test_ssl_dhparam.rb
+++ b/tests/test_ssl_dhparam.rb
@@ -1,84 +1,57 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 class TestSslDhParam < Test::Unit::TestCase
-  def setup
-    $dir = File.dirname(File.expand_path(__FILE__)) + '/'
-    $dhparam_file = File.join($dir, 'dhparam.pem')
-  end
 
-  module Client
-    def post_init
-      start_tls(:ssl_version => %w(TLSv1_2))
-    end
+  require_relative 'em_ssl_handlers'
+  include EMSSLHandlers
 
-    def ssl_handshake_completed
-      $client_handshake_completed = true
-      $client_cipher_name = get_cipher_name
-      close_connection
-    end
+  DH_PARAM_FILE = File.join(__dir__, 'dhparam.pem')
 
-    def unbind
-      EM.stop_event_loop
-    end
-  end
-
-  module Server
-    def post_init
-      start_tls(:dhparam => $dhparam_file, :cipher_list => "DHE,EDH", :ssl_version => %w(TLSv1_2))
-    end
-
-    def ssl_handshake_completed
-      $server_handshake_completed = true
-      $server_cipher_name = get_cipher_name
-    end
-  end
-
-  module NoDhServer
-    def post_init
-      start_tls(:cipher_list => "DHE,EDH", :ssl_version => %w(TLSv1_2))
-    end
-
-    def ssl_handshake_completed
-      $server_handshake_completed = true
-      $server_cipher_name = get_cipher_name
-    end
-  end
+  DH_1_2 =   { cipher_list: "DHE,EDH", ssl_version: %w(TLSv1_2) }
+  CLIENT_1_2 = { client_unbind: true,  ssl_version: %w(TLSv1_2) }
 
   def test_no_dhparam
-    omit("No SSL") unless EM.ssl?
     omit_if(EM.library_type == :pure_ruby) # DH will work with defaults
     omit_if(rbx?)
 
-    $client_handshake_completed, $server_handshake_completed = false, false
-    $server_cipher_name, $client_cipher_name = nil, nil
+    client_server client: CLIENT_1_2, server: DH_1_2
 
-    EM.run {
-      EM.start_server("127.0.0.1", 16784, NoDhServer)
-      EM.connect("127.0.0.1", 16784, Client)
-    }
-
-    assert(!$client_handshake_completed)
-    assert(!$server_handshake_completed)
+    refute Client.handshake_completed?
+    refute Server.handshake_completed?
   end
 
-  def test_dhparam
-    omit("No SSL") unless EM.ssl?
+  def test_dhparam_1_2
     omit_if(rbx?)
 
-    $client_handshake_completed, $server_handshake_completed = false, false
-    $server_cipher_name, $client_cipher_name = nil, nil
+    client_server client: CLIENT_1_2, server: DH_1_2.merge(dhparam: DH_PARAM_FILE)
 
-    EM.run {
-      EM.start_server("127.0.0.1", 16784, Server)
-      EM.connect("127.0.0.1", 16784, Client)
-    }
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
 
-    assert($client_handshake_completed)
-    assert($server_handshake_completed)
+    assert Client.cipher_name.length > 0
+    assert_equal Client.cipher_name, Server.cipher_name
 
-    assert($client_cipher_name.length > 0)
-    assert_equal($client_cipher_name, $server_cipher_name)
-
-    assert_match(/^(DHE|EDH)/, $client_cipher_name)
+    assert_match(/^(DHE|EDH)/, Client.cipher_name)
   end
-end
+
+  def test_dhparam_1_3
+    omit_if(rbx?)
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+
+    client = { client_unbind: true, ssl_version: %w(TLSv1_3) }
+    server = { dhparam: DH_PARAM_FILE, cipher_list: "DHE,EDH", ssl_version: %w(TLSv1_3) }
+    client_server client: client, server: server
+
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+
+    assert Client.cipher_name.length > 0
+    assert_equal Client.cipher_name, Server.cipher_name
+
+    # see https://wiki.openssl.org/index.php/TLS1.3#Ciphersuites
+    # may depend on OpenSSL build options
+    assert_equal "TLS_AES_256_GCM_SHA384", Client.cipher_name
+  end
+end if EM.ssl?

--- a/tests/test_ssl_ecdh_curve.rb
+++ b/tests/test_ssl_ecdh_curve.rb
@@ -1,125 +1,57 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 class TestSslEcdhCurve < Test::Unit::TestCase
 
-  if EM.ssl?
-    SSL_LIB_VERS = EM::OPENSSL_LIBRARY_VERSION[/OpenSSL (\d+\.\d+\.\d+)/, 1]
-      .split('.').map(&:to_i)
-  end
-
-  module Client
-    def post_init
-      start_tls
-    end
-
-    def ssl_handshake_completed
-      $client_handshake_completed = true
-      $client_cipher_name = get_cipher_name
-      close_connection unless /TLSv1\.3/i =~ get_cipher_protocol
-    end
-
-    def unbind
-      EM.stop_event_loop
-    end
-  end
-
-  module Server
-    def post_init
-      if (SSL_LIB_VERS <=> [1, 1]) == 1
-        start_tls(:cipher_list => "ECDH", :ssl_version => %w(TLSv1_2))
-      else
-        start_tls(:ecdh_curve => "prime256v1", :cipher_list => "ECDH", :ssl_version => %w(TLSv1_2))
-      end
-    end
-
-    def ssl_handshake_completed
-      $server_handshake_completed = true
-      $server_cipher_name = get_cipher_name
-    end
-  end
-
-  module Server1_3
-    def post_init
-      start_tls(:cipher_list => "ECDH", :ssl_version => %w(TLSv1_3))
-    end
-
-    def ssl_handshake_completed
-      $server_handshake_completed = true
-      $server_cipher_name = get_cipher_name
-      close_connection if /TLSv1\.3/i =~ get_cipher_protocol
-    end
-  end
-
-  module NoCurveServer
-    def post_init
-      start_tls(:cipher_list => "ECDH", :ssl_version => %w(TLSv1_2))
-    end
-
-    def ssl_handshake_completed
-      $server_handshake_completed = true
-      $server_cipher_name = get_cipher_name
-    end
-  end
+  require_relative 'em_ssl_handlers'
+  include EMSSLHandlers
 
   def test_no_ecdh_curve
-    omit("No SSL") unless EM.ssl?
     omit_if(rbx?)
-    omit("OpenSSL 1.1.x (and later) auto selects curve") if (SSL_LIB_VERS <=> [1, 1]) == 1
+    omit("OpenSSL 1.1.x (and later) auto selects curve") if IS_SSL_GE_1_1
 
-    $client_handshake_completed, $server_handshake_completed = false, false
+    client_server server: { cipher_list: "ECDH", ssl_version: %w(TLSv1_2) }
 
-    EM.run {
-      EM.start_server("127.0.0.1", 16784, NoCurveServer)
-      EM.connect("127.0.0.1", 16784, Client)
-    }
-
-    assert(!$client_handshake_completed)
-    assert(!$server_handshake_completed)
+    refute Client.handshake_completed?
+    refute Server.handshake_completed?
   end
 
-  def test_ecdh_curve
-    omit("No SSL") unless EM.ssl?
+  def test_ecdh_curve_tlsv1_2
     omit_if(EM.library_type == :pure_ruby && RUBY_VERSION < "2.3.0")
     omit_if(rbx?)
 
-    $client_handshake_completed, $server_handshake_completed = false, false
-    $server_cipher_name, $client_cipher_name = nil, nil
+    server = { cipher_list: "ECDH", ssl_version: %w(TLSv1_2) }
+    server.merge!(ecdh_curve: "prime256v1") unless IS_SSL_GE_1_1
 
-    EM.run {
-      EM.start_server("127.0.0.1", 16784, Server)
-      EM.connect("127.0.0.1", 16784, Client)
-    }
+    client_server server: server
 
-    assert($client_handshake_completed)
-    assert($server_handshake_completed)
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
 
-    assert($client_cipher_name.length > 0)
-    assert_equal($client_cipher_name, $server_cipher_name)
+    assert Client.cipher_name.length > 0
+    assert_equal Client.cipher_name, Server.cipher_name
 
-    assert_match(/^(AECDH|ECDHE)/, $client_cipher_name)
+    assert_match(/^(AECDH|ECDHE)/, Client.cipher_name)
   end
 
   def test_ecdh_curve_tlsv1_3
-    omit("No SSL") unless EM.ssl?
     omit_if(EM.library_type == :pure_ruby && RUBY_VERSION < "2.3.0")
     omit_if(rbx?)
     omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
 
-    $client_handshake_completed, $server_handshake_completed = false, false
-    $server_cipher_name, $client_cipher_name = nil, nil
+    tls = { cipher_list: "ECDH", ssl_version: %w(TLSv1_3) }
 
-    EM.run {
-      EM.start_server("127.0.0.1", 16784, Server1_3)
-      EM.connect("127.0.0.1", 16784, Client)
-    }
+    client_server server: tls
 
-    assert($client_handshake_completed)
-    assert($server_handshake_completed)
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
 
-    assert($client_cipher_name.length > 0)
-    assert_equal($client_cipher_name, $server_cipher_name)
+    assert Client.cipher_name.length > 0
+    assert_equal Client.cipher_name, Server.cipher_name
+
     # see https://wiki.openssl.org/index.php/TLS1.3#Ciphersuites
     # may depend on OpenSSL build options
-    assert_equal("TLS_AES_256_GCM_SHA384", $client_cipher_name)
+    assert_equal "TLS_AES_256_GCM_SHA384", Client.cipher_name
   end
-end
+end if EM.ssl?

--- a/tests/test_ssl_ecdh_curve.rb
+++ b/tests/test_ssl_ecdh_curve.rb
@@ -2,7 +2,7 @@
 
 require_relative 'em_test_helper'
 
-class TestSslEcdhCurve < Test::Unit::TestCase
+class TestSSLEcdhCurve < Test::Unit::TestCase
 
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers

--- a/tests/test_ssl_extensions.rb
+++ b/tests/test_ssl_extensions.rb
@@ -1,60 +1,24 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
-if EM.ssl?
-  class TestSslExtensions < Test::Unit::TestCase
+class TestSslExtensions < Test::Unit::TestCase
 
-    IP, PORT = "127.0.0.1", 16784
-  
-    module Client
-      def self.ssl_vers=(val = nil)
-        @@ssl_vers = val
-      end
+  require_relative 'em_ssl_handlers'
+  include EMSSLHandlers
 
-      def post_init
-        start_tls(:sni_hostname => 'example.com', :ssl_version => @@ssl_vers)
-      end
-    end
-
-    module Server
-      @@handshake_completed = false
-      @@sni_hostname = 'Not set'
-      
-      def self.handshake_completed? ; !!@@handshake_completed end
-      def self.sni_hostname         ;   @@sni_hostname        end
-
-      def post_init
-        start_tls
-      end
-
-      def ssl_handshake_completed
-        @@handshake_completed = true
-        @@sni_hostname = get_sni_hostname
-      end
-    end
-
-    def client_server(client = nil)
-      EM.run do
-        Client.ssl_vers = client
-        EM.start_server IP, PORT, Server
-        EM.connect IP, PORT, Client
-        EM.add_timer(0.3) { EM.stop_event_loop }
-      end
-    end
-    
-    def test_tlsext_sni_hostname_1_2
-      client_server %w(TLSv1_2)
-      assert Server.handshake_completed?
-      assert_equal 'example.com', Server.sni_hostname
-    end
-    
-    def test_tlsext_sni_hostname_1_3
-      omit("TLSv1_3 is unavailable") unless SSL_AVAIL.include? "tlsv1_3"
-      client_server %w(TLSv1_3)
-      assert Server.handshake_completed?
-      assert_equal 'example.com', Server.sni_hostname
-    end
-    
+  def test_tlsext_sni_hostname_1_2
+    client = { sni_hostname: 'example.com', ssl_version: %w(TLSv1_2) }
+    client_server client: client
+    assert Server.handshake_completed?
+    assert_equal 'example.com', Server.sni_hostname
   end
-else
-  warn "EM built without SSL support, skipping tests in #{__FILE__}"
-end
+  
+  def test_tlsext_sni_hostname_1_3
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+    client = { sni_hostname: 'example.com', ssl_version: %w(TLSv1_3) }
+    client_server client: client
+    assert Server.handshake_completed?
+    assert_equal 'example.com', Server.sni_hostname
+  end
+end if EM.ssl?

--- a/tests/test_ssl_extensions.rb
+++ b/tests/test_ssl_extensions.rb
@@ -2,7 +2,7 @@
 
 require_relative 'em_test_helper'
 
-class TestSslExtensions < Test::Unit::TestCase
+class TestSSLExtensions < Test::Unit::TestCase
 
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -1,234 +1,187 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
-if EM.ssl?
+# For OpenSSL 1.1.0 and later, cipher_protocol returns single cipher, older
+# versions return "TLSv1/SSLv3"
+# TLSv1.1 handshake_completed Server/Client callback order is reversed from
+# older protocols
 
-  class TestSslProtocols < Test::Unit::TestCase
+class TestSslProtocols < Test::Unit::TestCase
 
-    IP, PORT = "127.0.0.1", 16784
-    RUBY_SSL_GE_2_1 = OpenSSL::VERSION >= '2.1'
+  require_relative 'em_ssl_handlers'
+  include EMSSLHandlers
 
-    module Client
-      @@handshake_completed = false
+  RUBY_SSL_GE_2_1 = OpenSSL::VERSION >= '2.1'
 
-      def self.ssl_vers=(val = nil)
-        @@ssl_vers = val
-      end
-
-      def self.handshake_completed?
-        @@handshake_completed
-      end
-
-      def post_init
-        @@handshake_completed = false
-        if @@ssl_vers
-          start_tls(:ssl_version => @@ssl_vers)
-        else
-          start_tls
-        end
-      end
-
-      def ssl_handshake_completed
-        @@handshake_completed = true
-      end
-    end
-
-    module Server
-      @@handshake_completed = false
-
-      def self.ssl_vers=(val = nil)
-        @@ssl_vers = val
-      end
-
-      def self.handshake_completed? ; @@handshake_completed end
-
-      def post_init
-        @@handshake_completed = false
-        if @@ssl_vers
-          start_tls(:ssl_version => @@ssl_vers)
-        else
-          start_tls
-        end
-      end
-
-      def ssl_handshake_completed
-        @@handshake_completed = true
-      end
-    end
-
-    def client_server(client = nil, server = nil)
-      EM.run do
-        Client.ssl_vers, Server.ssl_vers = client, server
-        EM.start_server IP, PORT, Server
-        EM.connect IP, PORT, Client
-        EM.add_timer(0.3) { EM.stop_event_loop }
-      end
-    end
-
-    def test_invalid_ssl_version
-      assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do
-        client_server %w(tlsv1 badinput), %w(tlsv1 badinput)
-      end
-    end
-
-    def test_any_to_v3
-      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      client_server SSL_AVAIL, %w(SSLv3)
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_any_to_tlsv1_2
-      client_server SSL_AVAIL, %w(TLSv1_2)
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_case_insensitivity
-      lower_case = SSL_AVAIL.map { |p| p.downcase }
-      client_server %w(tlsv1), lower_case
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_v3_to_any
-      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      client_server %w(SSLv3), SSL_AVAIL
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_tlsv1_2_to_any
-      client_server %w(TLSv1_2), SSL_AVAIL
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_v3_to_v3
-      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      client_server %w(SSLv3), %w(SSLv3)
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_tlsv1_2_to_tlsv1_2
-      client_server %w(TLSv1_2), %w(TLSv1_2)
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_tlsv1_3_to_tlsv1_3
-      omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
-      client_server %w(TLSv1_3), %w(TLSv1_3)
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_any_to_any
-      client_server SSL_AVAIL, SSL_AVAIL
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    def test_default_to_default
-      client_server
-      assert Client.handshake_completed?
-      assert Server.handshake_completed?
-    end
-
-    module ServerStopAfterHandshake
-      def self.ssl_vers=(val)
-        @@ssl_vers = val
-      end
-
-      def self.handshake_completed? ; @@handshake_completed end
-
-      def post_init
-        @@handshake_completed = false
-        start_tls(:ssl_version => @@ssl_vers)
-      end
-
-      def ssl_handshake_completed
-        @@handshake_completed = true
-        EM.stop_event_loop
-      end
-    end
-
-    def external_client(ext_min, ext_max, ext_ssl, server)
-      EM.run do
-        setup_timeout(2)
-        ServerStopAfterHandshake.ssl_vers = server
-        EM.start_server(IP, PORT, ServerStopAfterHandshake)
-        EM.defer do
-          sock = TCPSocket.new(IP, PORT)
-          ctx = OpenSSL::SSL::SSLContext.new
-          if RUBY_SSL_GE_2_1
-            ctx.min_version = ext_min if ext_min
-            ctx.max_version = ext_max if ext_max
-          else
-            ctx.ssl_version = ext_ssl
-          end
-          ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-          ssl.connect
-          ssl.close rescue nil
-          sock.close rescue nil
-        end
-      end
-      assert ServerStopAfterHandshake.handshake_completed?
-    end
-
-    def test_v3_with_external_client
-      omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
-      external_client nil, nil, :SSLv3_client, %w(SSLv3)
-    end
-
-    # Fixed Server
-    def test_tlsv1_2_with_external_client
-      external_client nil, nil, :SSLv23_client, %w(TLSv1_2)
-    end
-
-    def test_tlsv1_3_with_external_client
-      omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
-      external_client nil, nil, :SSLv23_client, %w(TLSv1_3)
-    end
-
-    # Fixed Client
-    def test_any_with_external_client_tlsv1_2
-      external_client :TLS1_2, :TLS1_2, :TLSv1_2_client, SSL_AVAIL
-    end
-
-    def test_any_with_external_client_tlsv1_3
-      omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
-      external_client :TLS1_3, :TLS1_3, :TLSv1_2_client, SSL_AVAIL
-    end
-
-    # Refuse a client?
-    def test_tlsv1_2_required_with_external_client
-      EM.run do
-        n = 0
-        EM.add_periodic_timer(0.5) do
-          n += 1
-          (EM.stop rescue nil) if n == 2
-        end
-        ServerStopAfterHandshake.ssl_vers = %w(TLSv1_2)
-        EM.start_server(IP, PORT, ServerStopAfterHandshake)
-        EM.defer do
-          sock = TCPSocket.new(IP, PORT)
-          ctx = OpenSSL::SSL::SSLContext.new
-          if RUBY_SSL_GE_2_1
-            ctx.max_version = :TLS1_1
-          else
-            ctx.ssl_version = :TLSv1_client
-          end
-          ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-          assert_raise(OpenSSL::SSL::SSLError) { ssl.connect }
-          ssl.close rescue nil
-          sock.close rescue nil
-          EM.stop rescue nil
-        end
-      end
-      assert !ServerStopAfterHandshake.handshake_completed?
+  def test_invalid_ssl_version
+    assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do
+      client = { ssl_version: %w(tlsv1 badinput) }
+      server = { ssl_version: %w(tlsv1 badinput) }
+      client_server client: client, server: server
     end
   end
-else
-  warn "EM built without SSL support, skipping tests in #{__FILE__}"
-end
+
+  def test_any_to_v3
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    client_server client: TLS_ALL, server: SSL_3
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+  end
+
+  def test_any_to_tlsv1_2
+    client_server client: TLS_ALL, server: TLS_1_2
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+    if IS_SSL_GE_1_1
+      assert_equal "TLSv1.2", Client.cipher_protocol
+    end
+  end
+
+  def test_case_insensitivity
+    lower_case = SSL_AVAIL.map { |p| p.downcase }
+    client = { ssl_version: %w(tlsv1_2) }
+    server = { ssl_version: lower_case  }
+    client_server client: client, server: server
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+  end
+
+  def test_v3_to_any
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    client_server client: SSL_3, server: TLS_ALL
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+  end
+
+  def test_tlsv1_2_to_any
+    client_server client: TLS_1_2, server: TLS_ALL
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+    if IS_SSL_GE_1_1
+      assert_equal "TLSv1.2", Server.cipher_protocol
+    end
+  end
+
+  def test_v3_to_v3
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    client_server client: SSL_3, server: SSL_3
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+  end
+
+  def test_tlsv1_2_to_tlsv1_2
+    client_server client: TLS_1_2, server: TLS_1_2
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+    if IS_SSL_GE_1_1
+      assert_equal "TLSv1.2", Client.cipher_protocol
+      assert_equal "TLSv1.2", Server.cipher_protocol
+    end
+  end
+
+  def test_tlsv1_3_to_tlsv1_3
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+    client_server client: TLS_1_3, server: TLS_1_3
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+    assert_equal "TLSv1.3", Client.cipher_protocol
+    assert_equal "TLSv1.3", Server.cipher_protocol
+  end
+
+  def test_any_to_any
+    client_server client: TLS_ALL, server: TLS_ALL
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+    if IS_SSL_GE_1_1
+      best_protocol = SSL_AVAIL.last.tr "_", "."
+      assert_equal best_protocol, Client.cipher_protocol
+      assert_equal best_protocol, Server.cipher_protocol
+    end
+  end
+
+  def test_default_to_default
+    client_server
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+    if IS_SSL_GE_1_1
+      best_protocol = SSL_AVAIL.last.tr "_", "."
+      assert_equal best_protocol, Client.cipher_protocol
+      assert_equal best_protocol, Server.cipher_protocol
+    end
+  end
+
+  def external_client(ext_min, ext_max, ext_ssl, server)
+    EM.run do
+#        setup_timeout 2
+      EM.start_server IP, PORT, Server, server.merge( { stop_after_handshake: true} )
+      EM.defer do
+        sock = TCPSocket.new IP, PORT
+        ctx = OpenSSL::SSL::SSLContext.new
+        if RUBY_SSL_GE_2_1
+          ctx.min_version = ext_min if ext_min
+          ctx.max_version = ext_max if ext_max
+        else
+          ctx.ssl_version = ext_ssl
+        end
+        ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+        ssl.connect
+        ssl.close rescue nil
+        sock.close rescue nil
+      end
+    end
+    assert Server.handshake_completed?
+  end
+
+  def test_v3_with_external_client
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    external_client nil, nil, :SSLv3_client, SSL_3
+  end
+
+  # Fixed Server
+  def test_tlsv1_2_with_external_client
+    external_client nil, nil, :SSLv23_client, TLS_1_2
+  end
+
+  def test_tlsv1_3_with_external_client
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+    external_client nil, nil, :SSLv23_client, TLS_1_3
+  end
+
+  # Fixed Client
+  def test_any_with_external_client_tlsv1_2
+    external_client :TLS1_2, :TLS1_2, :TLSv1_2_client, TLS_ALL
+  end
+
+  def test_any_with_external_client_tlsv1_3
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+    external_client :TLS1_3, :TLS1_3, :TLSv1_2_client, TLS_ALL
+  end
+
+  # Refuse a client?
+  def test_tlsv1_2_required_with_external_client
+    EM.run do
+      n = 0
+      EM.add_periodic_timer(0.5) do
+        n += 1
+        (EM.stop rescue nil) if n == 2
+      end
+      EM.start_server IP, PORT, Server, TLS_1_2.merge( { stop_after_handshake: true} )
+      EM.defer do
+        sock = TCPSocket.new IP, PORT
+        ctx = OpenSSL::SSL::SSLContext.new
+        if RUBY_SSL_GE_2_1
+          ctx.max_version = :TLS1_1
+        else
+          ctx.ssl_version = :TLSv1_client
+        end
+        ssl = OpenSSL::SSL::SSLSocket.new sock, ctx
+        assert_raise(OpenSSL::SSL::SSLError) { ssl.connect }
+        ssl.close  rescue nil
+        sock.close rescue nil
+        EM.stop    rescue nil
+      end
+    end
+    refute Server.handshake_completed?
+  end
+end if EM.ssl?

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -7,7 +7,7 @@ require_relative 'em_test_helper'
 # TLSv1.1 handshake_completed Server/Client callback order is reversed from
 # older protocols
 
-class TestSslProtocols < Test::Unit::TestCase
+class TestSSLProtocols < Test::Unit::TestCase
 
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers

--- a/tests/test_ssl_verify.rb
+++ b/tests/test_ssl_verify.rb
@@ -2,7 +2,7 @@
 
 require_relative 'em_test_helper'
 
-class TestSslVerify < Test::Unit::TestCase
+class TestSSLVerify < Test::Unit::TestCase
 
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers

--- a/tests/test_ssl_verify.rb
+++ b/tests/test_ssl_verify.rb
@@ -1,154 +1,52 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 class TestSslVerify < Test::Unit::TestCase
 
-  DIR = File.dirname(File.expand_path(__FILE__)) + '/'
-  CERT_FROM_FILE = File.read(DIR+'client.crt')
+  require_relative 'em_ssl_handlers'
+  include EMSSLHandlers
 
-  IP, PORT = "127.0.0.1", 16784
+  CERT_FROM_FILE = File.read "#{__dir__}/client.crt"
 
-  module ClientNoCert
-    @@handshake_completed = nil
-    def self.handshake_completed? ; !!@@handshake_completed end
-
-    def post_init
-      @@handshake_completed = false
-      start_tls()
-    end
-
-    def ssl_handshake_completed
-      @@handshake_completed = true
-    end
-
-    def unbind
-      @@handshake_completed = false
-    end
-  end
-
-  module Client
-    @@handshake_completed = nil
-    def self.handshake_completed? ; !!@@handshake_completed end
-    def self.timer=(val)          ;   @@timer = val         end
-
-    def post_init #G connection_completed
-      @client_closed = false
-      @@handshake_completed = nil
-      @@timer = false
-      start_tls(:private_key_file => DIR+'client.key', :cert_chain_file => DIR+'client.crt')
-    end
-
-    def ssl_handshake_completed
-      @@handshake_completed = true
-    end
-
-    def unbind
-      @@handshake_completed = false unless @@timer
-    end
-  end
-
-  module AcceptServer
-    @@handshake_completed = nil
-    def self.handshake_completed? ; !!@@handshake_completed end
-    def self.cert ; @@cert end
-
-    def post_init
-      @@cert = nil
-      @@handshake_completed = false
-      start_tls(:verify_peer => true)
-    end
-
-    def ssl_verify_peer(cert)
-      @@cert = cert
-      true
-    end
-
-    def ssl_handshake_completed
-      @@handshake_completed = true
-    end
-  end
-
-  module DenyServer
-    @@handshake_completed = nil
-    def self.handshake_completed? ; !!@@handshake_completed end
-    def self.cert ; @@cert end
-
-    def post_init
-      @@cert = nil
-      @@handshake_completed = nil
-      start_tls(:verify_peer => true)
-    end
-
-    def ssl_verify_peer(cert)
-      @@cert = cert
-      # Do not accept the peer. This should now cause the connection to shut down without the SSL handshake being completed.
-      false
-    end
-
-    def ssl_handshake_completed
-      @@handshake_completed = true
-    end
-  end
-
-  module FailServerNoPeerCert
-    @@handshake_completed = nil
-    def self.handshake_completed? ; !!@@handshake_completed end
-
-    def post_init
-      @@handshake_completed = false
-      start_tls(:verify_peer => true, :fail_if_no_peer_cert => true)
-    end
-
-    def ssl_verify_peer(cert)
-      raise "Verify peer should not get called for a client without a certificate"
-    end
-
-    def ssl_handshake_completed
-      @@handshake_completed = true
-    end
-  end
-
-  def em_run(server, client)
-    EM.run {
-      EM.start_server IP, PORT, server
-      EM.connect IP, PORT, client
-      EM.add_timer(0.3) {
-        Client.timer = true
-        EM.stop_event_loop
-      }
-    }
-  end
+  CLIENT_CERT = { private_key_file: "#{__dir__}/client.key",
+                  cert_chain_file:  "#{__dir__}/client.crt" }
 
   def test_fail_no_peer_cert
-    omit("No SSL") unless EM.ssl?
     omit_if(rbx?)
 
-    em_run FailServerNoPeerCert, ClientNoCert
+    server = { verify_peer: true, fail_if_no_peer_cert: true,
+      ssl_verify_result: "|RAISE|Verify peer should not get called for a client without a certificate" }
 
-    assert !ClientNoCert.handshake_completed?
-    assert !FailServerNoPeerCert.handshake_completed?
+    client_server Client, Server, server: server
+
+    refute Client.handshake_completed? unless "TLSv1.3" == Client.cipher_protocol
+    refute Server.handshake_completed?
   end
 
   def test_accept_server
-    omit("No SSL") unless EM.ssl?
     omit_if(EM.library_type == :pure_ruby) # Server has a default cert chain
     omit_if(rbx?)
 
-    em_run AcceptServer, Client
+    server = { verify_peer: true, ssl_verify_result: true }
 
-    assert_equal CERT_FROM_FILE, AcceptServer.cert
+    client_server Client, Server, client: CLIENT_CERT, server: server
+
+    assert_equal CERT_FROM_FILE, Server.cert
     assert Client.handshake_completed?
-    assert AcceptServer.handshake_completed?
+    assert Server.handshake_completed?
   end
 
   def test_deny_server
-    omit("No SSL") unless EM.ssl?
     omit_if(EM.library_type == :pure_ruby) # Server has a default cert chain
     omit_if(rbx?)
 
-    em_run DenyServer, Client
+    server = { verify_peer: true, ssl_verify_result: false }
 
-    assert_equal CERT_FROM_FILE, DenyServer.cert
-    assert !Client.handshake_completed?
-    assert !DenyServer.handshake_completed?
+    client_server Client, Server, client: CLIENT_CERT, server: server
+
+    assert_equal CERT_FROM_FILE, Server.cert
+    refute Client.handshake_completed? unless "TLSv1.3" == Client.cipher_protocol
+    refute Server.handshake_completed?
   end
-end
+end if EM.ssl?


### PR DESCRIPTION
1. Remove global variables
2. All ssl tests use handlers in em_ssl_handlers.rb
3. Utilize native EM parameter passing to handlers
4. Add more asserts for cipher_name where applicable