### PR TITLE
pure_ruby: Allow sub-second intervals for timers

### DIFF
--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -136,7 +136,7 @@ module EventMachine
     # processor still wants them in seconds.
     # @private
     def add_oneshot_timer interval
-      Reactor.instance.install_oneshot_timer(interval / 1000)
+      Reactor.instance.install_oneshot_timer(interval.to_f / 1000)
     end
 
     # @private

--- a/tests/test_pure.rb
+++ b/tests/test_pure.rb
@@ -137,4 +137,20 @@ class TestPure < Test::Unit::TestCase
     assert($client_received_data == "Hello World!")
     assert($server_received_data == "Hello World!")
   end
+
+  def test_periodic_timer
+    x = 0
+    start, finish = nil
+
+    EM.run {
+      start = Time.now.to_f
+      EM::PeriodicTimer.new(0.2) do
+        x += 1
+        finish = Time.now.to_f
+        EM.stop if x == 4
+      end
+    }
+    assert_in_delta 0.8, (finish - start), 0.2
+    assert_equal 4, x
+  end
 end


### PR DESCRIPTION
`EventMachine::add_timer` passes the interval as int, leading to integer division and loss of sub-second intervals in the pure ruby implementation. Fix this by forcing float division.