### PR TITLE
Support compiling EventMachine on TruffleRuby

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -143,6 +143,8 @@ end
 
 # Main platform invariances:
 
+ldshared = CONFIG['LDSHARED']
+
 case RUBY_PLATFORM
 when /mswin32/, /mingw32/, /bccwin32/
   check_heads(%w[windows.h winsock.h], true)
@@ -220,6 +222,11 @@ when /cygwin/
 else
   # on Unix we need a g++ link, not gcc.
   CONFIG['LDSHARED'] = "$(CXX) -shared"
+end
+
+if RUBY_ENGINE == "truffleruby"
+  # Keep the original LDSHARED on TruffleRuby, as linking is done on bitcode
+  CONFIG['LDSHARED'] = ldshared
 end
 
 # Platform-specific time functions

--- a/ext/fastfilereader/extconf.rb
+++ b/ext/fastfilereader/extconf.rb
@@ -40,6 +40,8 @@ end
 
 # Main platform invariances:
 
+ldshared = CONFIG['LDSHARED']
+
 case RUBY_PLATFORM
 when /mswin32/, /mingw32/, /bccwin32/
   check_heads(%w[windows.h winsock.h], true)
@@ -104,6 +106,11 @@ when /cygwin/
 else
   # on Unix we need a g++ link, not gcc.
   CONFIG['LDSHARED'] = "$(CXX) -shared"
+end
+
+if RUBY_ENGINE == "truffleruby"
+  # Keep the original LDSHARED on TruffleRuby, as linking is done on bitcode
+  CONFIG['LDSHARED'] = ldshared
 end
 
 create_makefile "fastfilereaderext"

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -1050,7 +1050,7 @@ static VALUE t_unwatch_filename (VALUE self UNUSED, VALUE sig)
 	} catch (std::runtime_error e) {
 		rb_raise (EM_eInvalidSignature, "%s", e.what());
 	}
-	
+
 	return Qnil;
 }
 
@@ -1235,8 +1235,8 @@ t_set_rlimit_nofile
 
 static VALUE t_set_rlimit_nofile (VALUE self UNUSED, VALUE arg)
 {
-	arg = (NIL_P(arg)) ? -1 : NUM2INT (arg);
-	return INT2NUM (evma_set_rlimit_nofile (arg));
+	int arg_int = (NIL_P(arg)) ? -1 : NUM2INT (arg);
+	return INT2NUM (evma_set_rlimit_nofile (arg_int));
 }
 
 /***************************
@@ -1598,4 +1598,3 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_const(EmModule, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
 #endif
 }
-


### PR DESCRIPTION
This allows EventMachine to compile on TruffleRuby.
Although it does not run yet (e.g., `rb_thread_fd_select` is not yet implemented in TruffleRuby).

What's the status of the pure-Ruby backend? That would probably be easier to support than the C++ extension.