### PR TITLE
add failing test where comm_inactivity_timeout takes too long

### DIFF
--- a/tests/test_inactivity_timeout.rb
+++ b/tests/test_inactivity_timeout.rb
@@ -21,7 +21,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
     end
 
     def test_for_real
-      start, finish = nil
+      start, finish, reason = nil
 
       timeout_start = Module.new do
         define_method :post_init do
@@ -47,6 +47,49 @@ class TestInactivityTimeout < Test::Unit::TestCase
       }
       # Travis can vary from 0.02 to 0.17, Appveyor maybe as low as 0.01
       assert_in_delta(0.09, (finish - start), 0.08)
+
+      # simplified reproducer for comm_inactivity_timeout taking twice as long
+      # as requested -- https://github.com/eventmachine/eventmachine/issues/554
+      timeout_start_tls = Module.new do
+        define_method :post_init do
+          start = Time.now
+          start_tls
+        end
+        define_method :receive_data do |data|
+          send_data ">>>you sent: #{data}"
+        end
+      end
+
+      timeout_handler_tls = Module.new do
+        define_method :connection_completed do
+          start_tls
+        end
+
+        define_method :ssl_handshake_completed do
+          @timer = EM::PeriodicTimer.new(0.05) do
+            #puts "get_idle_time: #{get_idle_time} inactivity: #{comm_inactivity_timeout}"
+          end
+          send_data "hello world"
+        end
+
+        define_method :unbind do |r|
+          finish = Time.now
+          reason = r
+          EM.stop
+        end
+      end
+
+      EM.run {
+        setup_timeout 1.4
+        EM.start_server("127.0.0.1", 12345, timeout_start_tls)
+        c = EM.connect("127.0.0.1", 12345, timeout_handler_tls)
+        c.comm_inactivity_timeout = 0.15
+      }
+
+      # .30 is double the timeout and not acceptable
+      assert_in_delta(0.15, (finish - start), 0.14)
+      # make sure it was a timeout and not a TLS error
+      assert_equal Errno::ETIMEDOUT, reason
     end
   else
     warn "EM.comm_inactivity_timeout not implemented, skipping tests in #{__FILE__}"


### PR DESCRIPTION
Still seeing the behavior described in #554 where comm_inactivity_timeout sometimes takes twice the requested timeout value.  The code in the gist linked from there demonstrates the issue for me on multiple machines but only roughly ~5% of the time.

By reducing the timeout values by a factor of 100, it reproduces 100% of the time for me here locally.  Basically what is happening is that you request a timeout of say 15 seconds (15000000 microseconds) the heartbeat to check the inactivity time might arrive when the inactivity time is just under that value but really close e.g. 14998819 microseconds.  I've seen ranges of about 100-3500 microseconds difference.

Another heartbeat to check the inactivity won't be scheduled to arrive until the next interval so this is why it takes double the time.  So far this seems to be TLS-related.   If I disable TLS, I can't reproduce it.  Probably means the TLS overhead isn't being accounted somewhere.

I have a workaround prepared where it takes the Quantum value (default of 90000 microseconds) and adds it as a skew to the comparison but will try to find a proper fix.