### PR TITLE
adjust inactivity comparison so it will match nearly equal values

### DIFF
--- a/ext/em.cpp
+++ b/ext/em.cpp
@@ -221,6 +221,16 @@ bool EventMachine_t::Stopping()
 }
 
 /*******************************
+EventMachine_t::GetTimerQuantum
+*******************************/
+
+uint64_t EventMachine_t::GetTimerQuantum()
+{
+	/* Convert timer-quantum to microseconds */
+	return (Quantum.tv_sec * 1000 + (Quantum.tv_usec + 500) / 1000) * 1000;
+}
+
+/*******************************
 EventMachine_t::SetTimerQuantum
 *******************************/
 

--- a/ext/em.h
+++ b/ext/em.h
@@ -123,6 +123,7 @@ class EventMachine_t
 		void ArmKqueueWriter (EventableDescriptor*);
 		void ArmKqueueReader (EventableDescriptor*);
 
+		uint64_t GetTimerQuantum();
 		void SetTimerQuantum (int);
 		static void SetuidString (const char*);
 		static int SetRlimitNofile (int);


### PR DESCRIPTION
As discussed in #889, I tried various things but this is the only solution I've found that works.  I've tested it on a bunch of different hardware and it works fine even on very slow devices like the Raspberry Pi Zero.

Fixes #554.