### PR TITLE
Website URL appears to no longer be registered

### DIFF
--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/em/version', __FILE__)
 Gem::Specification.new do |s|
   s.name = 'eventmachine'
   s.version = EventMachine::VERSION
-  s.homepage = 'http://rubyeventmachine.com'
+  s.homepage = 'https://github.com/eventmachine/eventmachine'
   s.licenses = ['Ruby', 'GPL-2.0']
   s.required_ruby_version = '>= 2.0.0'
 


### PR DESCRIPTION
Hello,

It appears you're no longer maintaining the http://rubyeventmachine.com URL as I get redirected to http://www.inbudapesthotels.com/rubyeventmachinecom/. At least this fixes that in the short term.

Regards,
iain