### PR TITLE
Update for OpenSSL 1.1.1, travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 language: ruby
+cache: bundler
 bundler_args: --without documentation
 
 before_install:
@@ -7,8 +8,8 @@ before_install:
   # remove 2.7.0 code when Travis removes rubygems 2.7.8 from ruby-head build
   - |
     rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
-    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
-    elif [ "$rv" \< "2.7" ]; then gem update --system --no-document --conservative
+    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.9 --no-document
+    elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
     fi
 
 before_script:
@@ -19,6 +20,7 @@ script:
 
 env:
   global:
+    - env: OS="xenial 16.04"
     - TESTOPTS="-v  --no-show-detail-immediately"
 rvm:
   - 2.6
@@ -29,25 +31,34 @@ rvm:
   - 2.1
   - 2.0.0
   - ruby-head
-#  - rbx
-#  - rbx-2
-#  - rbx-3
-#  - jruby-1.7
-#  - jruby-9
+
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
-#    - rvm: rbx
-#    - rvm: rbx-2
-#    - rvm: rbx-3
-#    - rvm: jruby-1.7
-#    - rvm: jruby-9
-  include:
-    - rvm: 2.6
-      os: osx
-    - rvm: 2.3
-      os: osx
-    - rvm: 2.6
+    - rvm: ruby-head
       env:
         - RUBYOPT=--jit
+#    - rvm: jruby-9.2.7.0
+#    - rvm: jruby-head
+  include:
+    - rvm: 2.3
+      dist: trusty
+      env: OS="trusty 14.04"
+    - rvm: 2.6.3
+      dist: bionic
+      env: OS="bionic 18.04"
+    - rvm: 2.6
+      os: osx
+      osx_image: xcode10.2
+      env: OS="osx xcode 10.2"
+    - rvm: 2.3
+      os: osx
+      env: OS="osx"
+    - rvm: 2.6
+      env: RUBYOPT=--jit
+    - rvm: ruby-head
+      env:
+        - RUBYOPT=--jit
+#    - rvm: jruby-9.2.7.0
+#    - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
     fi
 
 before_script:
+  - if [ "$jit" == "yes" ]; then export RUBYOPT=--jit ; fi ; echo RUBYOPT is $RUBYOPT
   - bundle exec rake compile
 
 script:
@@ -20,8 +21,8 @@ script:
 
 env:
   global:
-    - env: OS="xenial 16.04"
     - TESTOPTS="-v  --no-show-detail-immediately"
+
 rvm:
   - 2.6
   - 2.5
@@ -37,28 +38,29 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head
-      env:
-        - RUBYOPT=--jit
+      env: jit=yes
 #    - rvm: jruby-9.2.7.0
 #    - rvm: jruby-head
   include:
     - rvm: 2.3
       dist: trusty
       env: OS="trusty 14.04"
-    - rvm: 2.6.3
+    - rvm: 2.6
       dist: bionic
       env: OS="bionic 18.04"
     - rvm: 2.6
       os: osx
       osx_image: xcode10.2
       env: OS="osx xcode 10.2"
+    - rvm: 2.6
+      os: osx
+      env: OS="osx"
     - rvm: 2.3
       os: osx
       env: OS="osx"
     - rvm: 2.6
-      env: RUBYOPT=--jit
+      env: jit=yes
     - rvm: ruby-head
-      env:
-        - RUBYOPT=--jit
+      env: jit=yes
 #    - rvm: jruby-9.2.7.0
 #    - rvm: jruby-head

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -238,6 +238,12 @@ else
   have_func('gethrtime') # Older Solaris and HP-UX
 end
 
+# OpenSSL version checks
+#   below are yes for 1.1.0 & later, may need to check func rather than macro
+#   with versions after 1.1.1
+have_func  "TLS_server_method"            , "openssl/ssl.h"
+have_macro "SSL_CTX_set_min_proto_version", "openssl/ssl.h"
+
 # Hack so that try_link will test with a C++ compiler instead of a C compiler
 TRY_LINK.sub!('$(CC)', '$(CXX)')
 

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -144,8 +144,11 @@ SslContext_t::SslContext_t (bool is_server, const std::string &privkeyfile, cons
 
 		InitializeDefaultCredentials();
 	}
-
+	#ifdef HAVE_TLS_SERVER_METHOD
+	pCtx = SSL_CTX_new (bIsServer ? TLS_server_method() : TLS_client_method());
+	#else
 	pCtx = SSL_CTX_new (bIsServer ? SSLv23_server_method() : SSLv23_client_method());
+	#endif
 	if (!pCtx)
 		throw std::runtime_error ("no SSL context");
 

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -5,7 +5,7 @@ class TestBasic < Test::Unit::TestCase
     @port = next_port
   end
 
-  INVALID = "(not known|no data of the requested|No such host is known)"
+  INVALID = "(not known|no data of the requested|No such host is known|Temporary failure in name resolution)"
 
   def test_connection_class_cache
     mod = Module.new

--- a/tests/test_resolver.rb
+++ b/tests/test_resolver.rb
@@ -86,7 +86,8 @@ class TestResolver < Test::Unit::TestCase
       d = EM::DNS::Resolver.resolve "localhost"
       d.errback { assert false }
       d.callback { |r|
-        assert_include(["127.0.0.1", "::1"], r.first)
+        # "127.0.1.1" added for testing on bionic 18.04
+        assert_include(["127.0.0.1", "127.0.1.1", "::1"], r.first)
         assert_kind_of(Array, r)
 
         EM.stop


### PR DESCRIPTION
1. Fixes #892, which was a OpenSSL issue with Ubuntu bionic 18.04.
2. Updated tests
3. RUBYOPT --jit moved to after bundle install (problems in my fork with CI)
4. Travis matrix now tests:
```
OpenSSL
1.0.1   trusty 14.04
1.0.2   xenial 16.04, osx
1.1.0   osx
1.1.1   bionic 18.04, osx/xcode
```