### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: >-
+      ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, macos ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, head ]
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: macOS disable firewall 
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+          sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+
+      - name: bundle install
+        run:  bundle install --jobs 4 --retry 3 --without=documentation
+
+      - name: compile
+        run:  bundle exec rake compile
+
+      - name: test
+        run:  bundle exec rake test
+        env:
+          CI: true
+          TESTOPTS: -v --no-show-detail-immediately
+
+  win32:
+    name: >-
+      ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, mingw ]
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby, update MSYS2, openssl
+        uses: MSP-Greg/actions-ruby@v1
+        with:
+          base:  update
+          mingw: openssl
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: bundle install
+        run:  bundle install --jobs 4 --retry 3 --without=documentation
+
+      - name: compile 
+        if:   matrix.ruby >= '2.4'
+        run:  rake compile
+
+      # Ruby 2.3 uses a OpenSSL package that is not MSYS2
+      - name: compile 2.3
+        if:   matrix.ruby == '2.3'
+        run:  rake compile -- --with-openssl-dir=C:/openssl-win
+
+      - name: test
+        run:  rake test
+        env:
+          CI: true
+          TESTOPTS: -v --no-show-detail-immediately

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,20 +6,25 @@ jobs:
   build:
     name: >-
       ${{ matrix.os }} ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos ]
+        os: [ ubuntu, macos, windows ]
         ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, head ]
+        include:
+          - { os: windows, ruby: mingw }
+        exclude:
+          - { os: windows, ruby: head }
     steps:
       - name: repo checkout
         uses: actions/checkout@v2
 
-      - name: load ruby
-        uses: ruby/setup-ruby@v1
+      - name: load ruby, openssl
+        uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          mingw: _upgrade_ openssl
 
       - name: macOS disable firewall 
         if: startsWith(matrix.os, 'macos')
@@ -35,44 +40,6 @@ jobs:
 
       - name: test
         run:  bundle exec rake test
-        env:
-          CI: true
-          TESTOPTS: -v --no-show-detail-immediately
-
-  win32:
-    name: >-
-      ${{ matrix.os }} ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest ]
-        ruby: [ 2.4, 2.5, 2.6, 2.7, mingw ]
-    steps:
-      - name: repo checkout
-        uses: actions/checkout@v2
-
-      - name: load ruby, update MSYS2, openssl
-        uses: MSP-Greg/actions-ruby@v1
-        with:
-          base:  update
-          mingw: openssl
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: bundle install
-        run:  bundle install --jobs 4 --retry 3 --without=documentation
-
-      - name: compile 
-        if:   matrix.ruby >= '2.4'
-        run:  rake compile
-
-      # Ruby 2.3 uses a OpenSSL package that is not MSYS2
-      - name: compile 2.3
-        if:   matrix.ruby == '2.3'
-        run:  rake compile -- --with-openssl-dir=C:/openssl-win
-
-      - name: test
-        run:  rake test
         env:
           CI: true
           TESTOPTS: -v --no-show-detail-immediately

--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -17,11 +17,13 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata=)
     s.metadata ||= {}
-    s.metadata["msys2_mingw_dependencies"] = "openssl"
+    if RbConfig::CONFIG['ruby_version'] >= '2.5'
+      s.metadata["msys2_mingw_dependencies"] = "openssl"
+    end
   end
 
   s.add_development_dependency 'test-unit', '~> 3.2'
-  s.add_development_dependency 'rake-compiler', '~> 1.0'
+  s.add_development_dependency 'rake-compiler', '~> 1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.6.3'
 
   s.summary = 'Ruby/EventMachine library'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -25,23 +25,9 @@ def append_library(libs, lib)
   libs + " " + format(LIBARG, lib)
 end
 
-SSL_HEADS = %w(openssl/ssl.h openssl/err.h)
-SSL_LIBS = %w(crypto ssl)
-# OpenSSL 1.1.0 and above for Windows use the Unix library names
-# OpenSSL 0.9.8 and 1.0.x for Windows use the *eay32 library names
-SSL_LIBS_WIN = RUBY_PLATFORM =~ /mswin|mingw|bccwin/ ? %w(ssleay32 libeay32) : []
-
 def dir_config_wrapper(pretty_name, name, idefault=nil, ldefault=nil)
   inc, lib = dir_config(name, idefault, ldefault)
   if inc && lib
-    # TODO: Remove when 2.0.0 is the minimum supported version
-    # Ruby versions not incorporating the mkmf fix at
-    # https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717
-    # do not properly search for lib directories, and must be corrected
-    unless lib && lib[-3, 3] == 'lib'
-      @libdir_basename = 'lib'
-      inc, lib = dir_config(name, idefault, ldefault)
-    end
     unless idefault && ldefault
       abort "-----\nCannot find #{pretty_name} include path #{inc}\n-----" unless inc && inc.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
       abort "-----\nCannot find #{pretty_name} library path #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
@@ -53,7 +39,7 @@ end
 
 def dir_config_search(pretty_name, name, paths, &b)
   paths.each do |p|
-    if dir_config_wrapper('OpenSSL', 'ssl', p + '/include', p + '/lib') && yield
+    if dir_config_wrapper(pretty_name, name, p + '/include', p + '/lib') && yield
       warn "-----\nFound #{pretty_name} in path #{p}\n-----"
       return true
     end
@@ -67,6 +53,20 @@ def pkg_config_wrapper(pretty_name, name)
     warn "-----\nUsing #{pretty_name} from pkg-config #{cflags} && #{ldflags} && #{libs}\n-----"
     true
   end
+end
+
+def find_openssl_library
+  if $mswin || $mingw
+    # required for static OpenSSL libraries
+    have_library("gdi32") # OpenSSL <= 1.0.2 (for RAND_screen())
+    have_library("crypt32")
+  end
+
+  return false unless have_header("openssl/ssl.h") && have_header("openssl/err.h")
+
+  ret = have_library("crypto", "CRYPTO_malloc") &&
+    have_library("ssl", "SSL_new")
+  return ret if ret
 end
 
 if ENV['CROSS_COMPILING']
@@ -86,17 +86,20 @@ if ENV['CROSS_COMPILING']
     STDERR.puts "**************************************************************************************"
     STDERR.puts
   end
+elsif dir_config_wrapper('OpenSSL', 'openssl')
+  # If the user has provided a --with-openssl-dir argument, we must respect it or fail.
+  add_define 'WITH_SSL' if find_openssl_library
 elsif dir_config_wrapper('OpenSSL', 'ssl')
   # If the user has provided a --with-ssl-dir argument, we must respect it or fail.
-  add_define 'WITH_SSL' if (check_libs(SSL_LIBS) || check_libs(SSL_LIBS_WIN)) && check_heads(SSL_HEADS)
+  add_define 'WITH_SSL' if find_openssl_librar
 elsif pkg_config_wrapper('OpenSSL', 'openssl')
   # If we can detect OpenSSL by pkg-config, use it as the next-best option
-  add_define 'WITH_SSL' if (check_libs(SSL_LIBS) || check_libs(SSL_LIBS_WIN)) && check_heads(SSL_HEADS)
-elsif (check_libs(SSL_LIBS) || check_libs(SSL_LIBS_WIN)) && check_heads(SSL_HEADS)
+  add_define 'WITH_SSL' if find_openssl_library
+elsif find_openssl_library
   # If we don't even need any options to find a usable OpenSSL, go with it
   add_define 'WITH_SSL'
-elsif dir_config_search('OpenSSL', 'ssl', ['/usr/local', '/opt/local', '/usr/local/opt/openssl']) do
-    (check_libs(SSL_LIBS) || check_libs(SSL_LIBS_WIN)) && check_heads(SSL_HEADS)
+elsif dir_config_search('OpenSSL', 'openssl', ['/usr/local', '/opt/local', '/usr/local/opt/openssl']) do
+    find_openssl_library
   end
   # Finally, look for OpenSSL in alternate locations including MacPorts and HomeBrew
   add_define 'WITH_SSL'
@@ -139,6 +142,8 @@ if RbConfig::CONFIG["host_os"] =~ /mingw/
     any? { |v| v.include?("FD_SETSIZE") }
 
   add_define "FD_SETSIZE=32767" unless found
+  # needed for new versions of headers-git & crt-git
+  append_ldflags "-l:libssp.a -fstack-protector"
 end
 
 # Main platform invariances:

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -143,7 +143,9 @@ if RbConfig::CONFIG["host_os"] =~ /mingw/
 
   add_define "FD_SETSIZE=32767" unless found
   # needed for new versions of headers-git & crt-git
-  append_ldflags "-l:libssp.a -fstack-protector"
+  if RbConfig::CONFIG["ruby_version"] >= "2.4"
+    append_ldflags "-l:libssp.a -fstack-protector"
+  end
 end
 
 # Main platform invariances:

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -91,7 +91,7 @@ elsif dir_config_wrapper('OpenSSL', 'openssl')
   add_define 'WITH_SSL' if find_openssl_library
 elsif dir_config_wrapper('OpenSSL', 'ssl')
   # If the user has provided a --with-ssl-dir argument, we must respect it or fail.
-  add_define 'WITH_SSL' if find_openssl_librar
+  add_define 'WITH_SSL' if find_openssl_library
 elsif pkg_config_wrapper('OpenSSL', 'openssl')
   # If we can detect OpenSSL by pkg-config, use it as the next-best option
   add_define 'WITH_SSL' if find_openssl_library

--- a/ext/fastfilereader/extconf.rb
+++ b/ext/fastfilereader/extconf.rb
@@ -37,7 +37,9 @@ if RbConfig::CONFIG["host_os"] =~ /mingw/
 
   add_define "FD_SETSIZE=32767" unless found
   # needed for new versions of headers-git & crt-git
-  append_ldflags "-l:libssp.a -fstack-protector"
+  if RbConfig::CONFIG["ruby_version"] >= "2.4"
+    append_ldflags "-l:libssp.a -fstack-protector"
+  end
 end
 
 # Main platform invariances:

--- a/ext/fastfilereader/extconf.rb
+++ b/ext/fastfilereader/extconf.rb
@@ -36,6 +36,8 @@ if RbConfig::CONFIG["host_os"] =~ /mingw/
     any? { |v| v.include?("FD_SETSIZE") }
 
   add_define "FD_SETSIZE=32767" unless found
+  # needed for new versions of headers-git & crt-git
+  append_ldflags "-l:libssp.a -fstack-protector"
 end
 
 # Main platform invariances:

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -106,7 +106,7 @@ task :devkit do
   end
 end
 
-if RUBY_PLATFORM =~ /mingw|mswin/
+if RUBY_PLATFORM =~ /mingw|mswin/ && ENV['GITHUB_ACTIONS'].nil?
   Rake::Task['compile'].prerequisites.unshift 'devkit'
 end
 

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -129,6 +129,10 @@ class Test::Unit::TestCase
       RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     end
 
+    def darwin?
+      RUBY_PLATFORM =~ /darwin/
+    end
+
     def solaris?
       RUBY_PLATFORM =~ /solaris/
     end

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -163,7 +163,7 @@ class TestBasic < Test::Unit::TestCase
     end
 
     EM.run do
-      setup_timeout(darwin? ? 0.3 : nil)
+      darwin? ? setup_timeout(0.3) : setup_timeout
       EM.start_server "127.0.0.1", @port, bound_server
       EM.bind_connect local_ip, bind_port, "127.0.0.1", @port
     end

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -38,7 +38,7 @@ class TestBasic < Test::Unit::TestCase
   def test_timer
     assert_nothing_raised do
       EM.run {
-        setup_timeout 0.4
+        setup_timeout(darwin? ? 0.6 : 0.4)
         n = 0
         EM.add_periodic_timer(0.1) {
           n += 1
@@ -163,7 +163,7 @@ class TestBasic < Test::Unit::TestCase
     end
 
     EM.run do
-      setup_timeout
+      setup_timeout(darwin? ? 0.3 : nil)
       EM.start_server "127.0.0.1", @port, bound_server
       EM.bind_connect local_ip, bind_port, "127.0.0.1", @port
     end

--- a/tests/test_idle_connection.rb
+++ b/tests/test_idle_connection.rb
@@ -25,7 +25,7 @@ class TestIdleConnection < Test::Unit::TestCase
       end
     end
 
-    assert_in_delta 0.3, a, 0.1
+    assert_in_delta 0.3, a, (darwin? ? 0.2 : 0.1)
     assert_in_delta 0, b, 0.1
   end
 end

--- a/tests/test_inactivity_timeout.rb
+++ b/tests/test_inactivity_timeout.rb
@@ -46,7 +46,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
         }
       }
       # Travis can vary from 0.02 to 0.17, Appveyor maybe as low as 0.01
-      assert_in_delta(0.09, (finish - start), 0.08)
+      assert_in_delta 0.09, (finish - start), (darwin? ? 0.10 : 0.08)
 
       # simplified reproducer for comm_inactivity_timeout taking twice as long
       # as requested -- https://github.com/eventmachine/eventmachine/issues/554

--- a/tests/test_inactivity_timeout.rb
+++ b/tests/test_inactivity_timeout.rb
@@ -87,7 +87,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
       }
 
       # .30 is double the timeout and not acceptable
-      assert_in_delta(0.15, (finish - start), 0.14)
+      assert_in_delta 0.15, (finish - start), (darwin? ? 0.20 : 0.14)
       # make sure it was a timeout and not a TLS error
       assert_equal Errno::ETIMEDOUT, reason
     end

--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -33,7 +33,7 @@ class TestIPv4 < Test::Unit::TestCase
 
     @@received_data = nil
     @local_port = next_port
-    setup_timeout(2)
+    setup_timeout(darwin? ? 4 : 2)
 
     EM.run do
       EM::open_datagram_socket(@@public_ipv4, @local_port) do |s|

--- a/tests/test_pause.rb
+++ b/tests/test_pause.rb
@@ -48,7 +48,9 @@ class TestPause < Test::Unit::TestCase
         EM.start_server "127.0.0.1", @port, test_server
         EM.connect "127.0.0.1", @port, test_client
 
-        EM.add_timer(0.05) do
+        tmr = darwin? ? 0.10 : 0.05
+
+        EM.add_timer(tmr) do
           assert_equal 1, s_rx
           assert_equal 0, c_rx
           assert server.paused?
@@ -58,7 +60,7 @@ class TestPause < Test::Unit::TestCase
 
           assert !server.paused?
 
-          EM.add_timer(0.05) do
+          EM.add_timer(tmr) do
             assert server.paused?
             assert s_rx > 1
             assert c_rx > 0

--- a/tests/test_pure.rb
+++ b/tests/test_pure.rb
@@ -150,7 +150,7 @@ class TestPure < Test::Unit::TestCase
         EM.stop if x == 4
       end
     }
-    assert_in_delta 0.8, (finish - start), 0.2
+    assert_in_delta 0.8, (finish - start), (darwin? ? 0.6 : 0.2)
     assert_equal 4, x
   end
 end

--- a/tests/test_resolver.rb
+++ b/tests/test_resolver.rb
@@ -2,7 +2,8 @@ require_relative 'em_test_helper'
 
 class TestResolver < Test::Unit::TestCase
 
-  CI_WINDOWS = windows? and ENV['CI'].casecmp('true').zero?
+  # always true unless set
+  CI_WINDOWS = windows? && ENV.fetch('CI', 'true').casecmp('true').zero?
 
   def ci_windows_retries(err)
     if CI_WINDOWS and err.is_a? String and err[/retries exceeded/]

--- a/tests/test_send_file.rb
+++ b/tests/test_send_file.rb
@@ -179,7 +179,7 @@ class TestSendFile < Test::Unit::TestCase
 
       EM.run {
         EM.start_server "127.0.0.1", @port, StreamTestModule, @filename
-        setup_timeout
+        setup_timeout(darwin? ? 0.5 : 0.25)
         EM.connect "127.0.0.1", @port, TestClient do |c|
           c.data_to { |d| data << d }
         end

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -12,7 +12,9 @@ class TestSSLProtocols < Test::Unit::TestCase
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers
 
-  RUBY_SSL_GE_2_1 =  OpenSSL::SSL::SSLContext.instance_methods(false).include?(:min_version=)
+  # We're checking for whether Context min_version= & max_version= are defined, but
+  # JRuby has a bug where they're defined, but the private method they call isn't
+  RUBY_SSL_GE_2_1 = OpenSSL::SSL::SSLContext.private_instance_methods(false).include?(:set_minmax_proto_version)
 
   def test_invalid_ssl_version
     assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -12,7 +12,7 @@ class TestSSLProtocols < Test::Unit::TestCase
   require_relative 'em_ssl_handlers'
   include EMSSLHandlers
 
-  RUBY_SSL_GE_2_1 = OpenSSL::VERSION >= '2.1'
+  RUBY_SSL_GE_2_1 =  OpenSSL::SSL::SSLContext.instance_methods(false).include?(:min_version=)
 
   def test_invalid_ssl_version
     assert_raises(RuntimeError, "Unrecognized SSL/TLS Version: badinput") do
@@ -144,7 +144,8 @@ class TestSSLProtocols < Test::Unit::TestCase
   end
 
   def test_tlsv1_3_with_external_client
-    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+    omit("TLSv1_3 is unavailable") unless EM.const_defined?(:EM_PROTO_TLSv1_3) &&
+      OpenSSL::SSL.const_defined?(:TLS1_3_VERSION)
     external_client nil, nil, :SSLv23_client, TLS_1_3
   end
 


### PR DESCRIPTION
Six commits:

1. 'extconf.rb updates' - Some Windows specific, others are update & cleanup for OpenSSL checks

2. 'package.rake - remove devkit on GitHub Actions' - At present, Actions does not have a standard MSYS2 install, and also does not have RubyInstaller devkits (Ruby 2.3 and older).  The devkit paths are enabled by the actions used to load Ruby.

3. 'eventmachine.gemspec - s.metadata["msys2_mingw_dependencies"]' - The metadata tag updates the MinGW OpenSSL package, but the current package (1.1.1) is incompatible with Ruby 2.4, which uses 1.0.2

4. 'test adjustments - darwin, some windows'

5. 'Add GitHub Actions workflow.yml' - tests on Ubuntu & macOS, Ruby 2.2. thru master, Windows Ruby 2.4 thru master.  On all three OS's, older Ruby version use OpenSSL 1.0.2, newer versions use 1.1.1.

6. 'test_idle_connection.rb - macOS delta fix' - the one test in commit 4 that I inadvertently did not add a darwin conditional to.  Fixed and adjusted again.