### PR TITLE
Add requirement for em/pure_ruby

### DIFF
--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -1,3 +1,5 @@
+require 'em/pure_ruby'
+
 if defined?(EventMachine.library_type) and EventMachine.library_type == :pure_ruby
   # assume 'em/pure_ruby' was loaded already
 elsif RUBY_PLATFORM =~ /java/


### PR DESCRIPTION
I have no idea what I'm doing here. I wanted to use [MailCatcher](https://mailcatcher.me/) on macOS Catalina (10.15.6) and got this error:

```
Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'
Traceback (most recent call last):
	10: from /usr/local/bin/mailcatcher:23:in `<main>'
	 9: from /usr/local/bin/mailcatcher:23:in `load'
	 8: from /Library/Ruby/Gems/2.6.0/gems/mailcatcher-0.7.1/bin/mailcatcher:3:in `<top (required)>'
	 7: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 6: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 5: from /Library/Ruby/Gems/2.6.0/gems/mailcatcher-0.7.1/lib/mail_catcher.rb:15:in `<top (required)>'
	 4: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 3: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	 2: from /Library/Ruby/Gems/2.6.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:8:in `<top (required)>'
	 1: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': dlopen(/Library/Ruby/Gems/2.6.0/gems/eventmachine-1.0.9.1/lib/rubyeventmachine.bundle, 0x0009): dependent dylib '/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib' not found for '/Library/Ruby/Gems/2.6.0/gems/eventmachine-1.0.9.1/lib/rubyeventmachine.bundle' - /Library/Ruby/Gems/2.6.0/gems/eventmachine-1.0.9.1/lib/rubyeventmachine.bundle (LoadError)
```

I then asked Google for help and found [this comment](https://github.com/tabler/tabler/issues/155#issuecomment-398533641) that claimed to have solved the problem. What he described seemed similar enough to be the related to my problem, so I tried his solution. And it worked.

I have no knowledge of Ruby at all. I just made this change because it fixes my problem. Maybe the folks here that are more familiar with Ruby will find a better solution.