### PR TITLE
Fixes for Ruby 3, misc

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,10 +7,11 @@ jobs:
     name: >-
       ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
         ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
         include:
           - { os: windows-2019, ruby: mingw }

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ java/src/.project
 *.rbc
 Gemfile.lock
 
+vendor/bundle/
 .yardoc/*
 doc/*
 tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gemspec
 
 gem 'rake'
 
+install_if -> { RUBY_VERSION > '3.1' } do
+  gem "net-smtp"
+end
+
 group :documentation do
   gem 'yard', '>= 0.8.5.2'
   gem 'redcarpet' unless RUBY_PLATFORM =~ /java|mswin/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,10 @@
 ---
+image:
+- Visual Studio 2019
+
+build: off
+deploy: off
+
 install:
   # download shared script files
   - ps: >-

--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -17,9 +17,7 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata=)
     s.metadata ||= {}
-    if RbConfig::CONFIG['ruby_version'] >= '2.5'
-      s.metadata["msys2_mingw_dependencies"] = "openssl"
-    end
+    s.metadata["msys2_mingw_dependencies"] = "openssl"
   end
 
   s.add_development_dependency 'test-unit', '~> 3.2'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -138,6 +138,9 @@ else
   add_define "HAVE_KQUEUE" if have_header("sys/event.h") && have_header("sys/queue.h")
 end
 
+# Add for changes to Process::Status in Ruby 3
+add_define("IS_RUBY_3_OR_LATER") if RUBY_VERSION > "3.0"
+
 # Adjust number of file descriptors (FD) on Windows
 
 if RbConfig::CONFIG["host_os"] =~ /mingw/

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -85,7 +85,24 @@ static VALUE Intern_proxy_target_unbound;
 static VALUE Intern_proxy_completed;
 static VALUE Intern_connection_completed;
 
-static VALUE rb_cProcStatus;
+static VALUE rb_cProcessStatus;
+
+#ifdef IS_RUBY_3_OR_LATER
+struct rb_process_status {
+    rb_pid_t pid;
+    int status;
+    int error;
+};
+
+static const rb_data_type_t rb_process_status_type = {
+    .wrap_struct_name = "Process::Status",
+    .function = {
+        .dfree = RUBY_DEFAULT_FREE,
+    },
+    .data = NULL,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+#endif
 
 struct em_event {
 	uintptr_t signature;
@@ -553,11 +570,18 @@ static VALUE t_get_subprocess_status (VALUE self UNUSED, VALUE signature)
 
 	if (evma_get_subprocess_status (NUM2BSIG (signature), &status)) {
 		if (evma_get_subprocess_pid (NUM2BSIG (signature), &pid)) {
-			proc_status = rb_obj_alloc(rb_cProcStatus);
 
+#ifdef IS_RUBY_3_OR_LATER
+			struct rb_process_status *data = NULL;
+			proc_status = TypedData_Make_Struct(rb_cProcessStatus, struct rb_process_status, &rb_process_status_type, data);
+			data->pid = pid;
+			data->status = status;
+#else
+			proc_status = rb_obj_alloc(rb_cProcessStatus);
 			/* MRI Ruby uses hidden instance vars */
-			rb_iv_set(proc_status, "status", INT2FIX(status));
-			rb_iv_set(proc_status, "pid", INT2FIX(pid));
+			rb_ivar_set(proc_status, rb_intern_const("status"), INT2FIX(status));
+			rb_ivar_set(proc_status, rb_intern_const("pid"), INT2FIX(pid));
+#endif
 
 #ifdef RUBINIUS
 			/* Rubinius uses standard instance vars */
@@ -572,7 +596,7 @@ static VALUE t_get_subprocess_status (VALUE self UNUSED, VALUE signature)
 #endif
 		}
 	}
-
+	rb_obj_freeze(proc_status);
 	return proc_status;
 }
 
@@ -1431,7 +1455,7 @@ extern "C" void Init_rubyeventmachine()
 {
 	// Lookup Process::Status for get_subprocess_status
 	VALUE rb_mProcess = rb_const_get(rb_cObject, rb_intern("Process"));
-	rb_cProcStatus = rb_const_get(rb_mProcess, rb_intern("Status"));
+	rb_cProcessStatus = rb_const_get(rb_mProcess, rb_intern("Status"));
 
 	// Tuck away some symbol values so we don't have to look 'em up every time we need 'em.
 	Intern_at_signature = rb_intern ("@signature");

--- a/tests/test_io_streamer.rb
+++ b/tests/test_io_streamer.rb
@@ -2,6 +2,7 @@
 
 require_relative 'em_test_helper'
 require 'em/io_streamer'
+require 'stringio'
 
 # below to stop 'already initialized constant' warning
 EM::IOStreamer.__send__ :remove_const, :CHUNK_SIZE

--- a/tests/test_processes.rb
+++ b/tests/test_processes.rb
@@ -32,23 +32,42 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system
+      out, status = nil, nil
+
       EM.run{
-        EM.system('ls'){ |out,status| $out, $status = out, status; EM.stop }
+        EM.system('ls'){ |_out,_status| out, status = _out, _status; EM.stop }
       }
 
-      assert( $out.length > 0 )
-      assert_equal(0, $status.exitstatus)
-      assert_kind_of(Process::Status, $status)
+      assert(out.length > 0 )
+      assert_kind_of(Process::Status, status)
+      assert_equal(0, status.exitstatus)
+    end
+
+    def test_em_system_bad_exitstatus
+      status = nil
+      sys_pid = nil
+
+      EM.run{
+        sys_pid = EM.system('exit 1'){ |_out,_status| status = _status; EM.stop }
+      }
+
+      assert_kind_of(Process::Status, status)
+      refute_equal(0, status.exitstatus)
+      assert_equal sys_pid, status.pid
     end
 
     def test_em_system_pid
-      $pids = []
+      status = nil
+      sys_pid = nil
 
       EM.run{
-        $pids << EM.system('echo hi', proc{ |out,status|$pids << status.pid; EM.stop })
+        sys_pid = EM.system('echo hi', proc{ |_out,_status| status = _status; EM.stop })
       }
 
-      assert_equal $pids[0], $pids[1]
+      refute_equal(0, sys_pid)
+      assert_kind_of(Process::Status, status)
+      refute_equal(0, status.pid)
+      assert_equal sys_pid, status.pid
     end
 
     def test_em_system_with_proc
@@ -57,8 +76,8 @@ class TestProcesses < Test::Unit::TestCase
       }
 
       assert( $out.length > 0 )
-      assert_equal(0, $status.exitstatus)
       assert_kind_of(Process::Status, $status)
+      assert_equal(0, $status.exitstatus)
     end
 
     def test_em_system_with_two_procs

--- a/win_gem_test/eventmachine.ps1
+++ b/win_gem_test/eventmachine.ps1
@@ -1,4 +1,5 @@
-# PowerShell script for building & testing SQLite3-Ruby fat binary gem
+# PowerShell script for building & testing EventMachine pre-compiled gem
+# builds EM with ssl support
 # Code by MSP-Greg, see https://github.com/MSP-Greg/av-gem-build-test
 
 # load utility functions, pass 64 or 32
@@ -13,10 +14,10 @@ Make-Const repo_name 'eventmachine'
 Make-Const url_repo  'https://github.com/eventmachine/eventmachine.git'
 
 #———————————————————————————————————————————————————————————————— lowest ruby version
-Make-Const ruby_vers_low 20
+Make-Const ruby_vers_low 22
 # null = don't compile; false = compile, ignore test (allow failure);
 # true = compile & test
-Make-Const trunk     $false ; Make-Const trunk_x64     $false
+Make-Const trunk     $null  ; Make-Const trunk_x64     $null
 Make-Const trunk_JIT $null  ; Make-Const trunk_x64_JIT $null
 
 #———————————————————————————————————————————————————————————————— make info


### PR DESCRIPTION
This has several commits.  Most importantly, it updates EM to work with Ruby 3, as changes to Process::Status were needed.

It also updates test_process.rb and various files for local use and testing.

On AppVeyor, it successfully builds a Windows gem for use with Ruby 2.2 thru 3.0, both 64 and 32 bit.