### PR TITLE
Add preverify_ok and X509_STORE_CTX to verify_peer

### DIFF
--- a/BSDL-openssl
+++ b/BSDL-openssl
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/COPYING-openssl
+++ b/COPYING-openssl
@@ -1,0 +1,56 @@
+Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
+You can redistribute it and/or modify it under either the terms of the
+2-clause BSDL (see the file BSDL-openssl), or the conditions below:
+
+  1. You may make and give away verbatim copies of the source form of the
+     software without restriction, provided that you duplicate all of the
+     original copyright notices and associated disclaimers.
+
+  2. You may modify your copy of the software in any way, provided that
+     you do at least ONE of the following:
+
+       a) place your modifications in the Public Domain or otherwise
+          make them Freely Available, such as by posting said
+	  modifications to Usenet or an equivalent medium, or by allowing
+	  the author to include your modifications in the software.
+
+       b) use the modified software only within your corporation or
+          organization.
+
+       c) give non-standard binaries non-standard names, with
+          instructions on where to get the original software distribution.
+
+       d) make other distribution arrangements with the author.
+
+  3. You may distribute the software in object code or binary form,
+     provided that you do at least ONE of the following:
+
+       a) distribute the binaries and library files of the software,
+	  together with instructions (in the manual page or equivalent)
+	  on where to get the original distribution.
+
+       b) accompany the distribution with the machine-readable source of
+	  the software.
+
+       c) give non-standard binaries non-standard names, with
+          instructions on where to get the original software distribution.
+
+       d) make other distribution arrangements with the author.
+
+  4. You may modify and include the part of the software into any other
+     software (possibly commercial).  But some files in the distribution
+     are not written by the author, so that they are not under these terms.
+
+     For the list of those files and their copying conditions, see the
+     file LEGAL.
+
+  5. The scripts and library files supplied as input to or produced as
+     output from the software do not automatically fall under the
+     copyright of the software, but belong to whomever generated them,
+     and may be sold commercially, and may be aggregated with this
+     software.
+
+  6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+     PURPOSE.

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1494,12 +1494,12 @@ ConnectionDescriptor::VerifySslPeer
 ***********************************/
 
 #ifdef WITH_SSL
-bool ConnectionDescriptor::VerifySslPeer(const char *cert)
+bool ConnectionDescriptor::VerifySslPeer(int ok, X509_STORE_CTX *ctx)
 {
 	bSslPeerAccepted = false;
 
 	if (EventCallback)
-		(*EventCallback)(GetBinding(), EM_SSL_VERIFY, cert, strlen(cert));
+		(*EventCallback)(GetBinding(), EM_SSL_VERIFY, (const char *)ctx, ok);
 
 	return bSslPeerAccepted;
 }

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -221,7 +221,7 @@ class ConnectionDescriptor: public EventableDescriptor
 		virtual const char *GetCipherName();
 		virtual const char *GetCipherProtocol();
 		virtual const char *GetSNIHostname();
-		virtual bool VerifySslPeer(const char*);
+		virtual bool VerifySslPeer(int, X509_STORE_CTX *);
 		virtual void AcceptSslPeer();
 		#endif
 

--- a/ext/em_ossl.c
+++ b/ext/em_ossl.c
@@ -1,0 +1,67 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#include "em_ossl.h"
+#include <stdarg.h> /* for ossl_raise */
+
+#ifdef WITH_SSL
+
+/*
+ * Data Conversion
+ */
+
+/* adapted from stdlib openssl's ossl_str_new_i */
+static VALUE em_ssl_str_new_i(VALUE size)
+{
+	return rb_str_new(NULL, (long)size);
+}
+
+/* adapted from stdlib openssl's ossl_str_new */
+VALUE em_ssl_str_new(const char *ptr, long len, int *pstate)
+{
+	VALUE str;
+	int state;
+
+	str = rb_protect(em_ssl_str_new_i, len, &state);
+	if (pstate)
+		*pstate = state;
+	if (state) {
+		if (!pstate)
+			rb_set_errinfo(Qnil);
+		return Qnil;
+	}
+	if (ptr)
+		memcpy(RSTRING_PTR(str), ptr, len);
+	return str;
+}
+
+/*
+ * main module
+ */
+VALUE mEmSsl;
+
+#endif /* WITH_SSL */
+
+void Init_em_ssl(void)
+{
+#ifdef WITH_SSL
+	/*
+	 * Init main module
+	 */
+	VALUE rb_mEM = rb_const_get(rb_cObject, rb_intern("EventMachine"));
+	rb_global_variable(&mEmSsl);
+	mEmSsl = rb_define_module_under (rb_mEM, "SSL");
+
+	Init_em_ssl_x509();
+#endif /* WITH_SSL */
+}

--- a/ext/em_ossl.h
+++ b/ext/em_ossl.h
@@ -1,0 +1,58 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#if !defined(_EM_OSSL_H_)
+#define _EM_OSSL_H_
+
+#ifdef WITH_SSL
+
+/*#include RUBY_EXTCONF_H */
+
+#include <assert.h>
+#include <ruby.h>
+#include <errno.h>
+#include <ruby/io.h>
+#include <ruby/thread.h>
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Common Module
+ */
+extern VALUE mEmSsl;
+
+/*
+ * Data Conversion
+ */
+VALUE em_ssl_str_new(const char *, long, int *);
+
+/*
+ * Include all parts
+ */
+#include "em_ossl_bio.h"
+#include "em_ossl_x509.h"
+
+#endif /* WITH_SSL */
+
+void Init_em_ssl(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _EM_OSSL_H_ */

--- a/ext/em_ossl_bio.c
+++ b/ext/em_ossl_bio.c
@@ -1,0 +1,30 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#include "em_ossl.h"
+
+/* adapted from stdlib openssl's ossl_membio2str */
+VALUE em_ssl_membio2str(BIO *bio)
+{
+	VALUE ret;
+	int state;
+	BUF_MEM *buf;
+
+	BIO_get_mem_ptr(bio, &buf);
+	ret = em_ssl_str_new(buf->data, buf->length, &state);
+	BIO_free(bio);
+	if (state)
+		rb_jump_tag(state);
+
+	return ret;
+}

--- a/ext/em_ossl_bio.h
+++ b/ext/em_ossl_bio.h
@@ -1,0 +1,20 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#if !defined(_EM_OSSL_BIO_H_)
+#define _EM_OSSL_BIO_H_
+
+/* BIO *emssl_obj2bio(volatile VALUE *); */
+VALUE em_ssl_membio2str(BIO*);
+
+#endif

--- a/ext/em_ossl_x509.c
+++ b/ext/em_ossl_x509.c
@@ -1,0 +1,23 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#include "em_ossl.h"
+
+VALUE mEmSslX509;
+
+void Init_em_ssl_x509(void)
+{
+	mEmSslX509 = rb_define_module_under (mEmSsl, "X509");
+
+	Init_em_ssl_x509store();
+}

--- a/ext/em_ossl_x509.h
+++ b/ext/em_ossl_x509.h
@@ -1,0 +1,46 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+
+#if !defined(_EM_OSSL_X509_H_)
+#define _EM_OSSL_X509_H_
+
+/*
+ * X509 main module
+ */
+extern VALUE mEmSslX509;
+
+void Init_em_ssl_x509(void);
+
+/*
+ * X509Store and X509StoreContext
+ */
+extern VALUE cEmSslX509StoreContext;
+
+void Init_em_ssl_x509store(void);
+
+/*
+ * Calls the verify callback Proc (the first parameter) with given pre-verify
+ * result and the X509_STORE_CTX.
+ */
+int em_ssl_verify_cb_call(VALUE, int, X509_STORE_CTX *);
+
+/*
+ * Input is X509*, unlike ossl_x509_to_pem which is an instance method (so the
+ * input is VALUE self).
+ *
+ * Also, since it's not an instance method, it's not static.
+ */
+VALUE em_ssl_x509_to_pem(X509 *x509);
+
+#endif /* _EM_OSSL_X509_H_ */

--- a/ext/em_ossl_x509cert.c
+++ b/ext/em_ossl_x509cert.c
@@ -1,0 +1,37 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#include "em_ossl.h"
+
+/*
+ * Adapted from stdlib openssl's ossl_x509_to_pem.
+ *
+ * Input is X509*, unlike ossl_x509_to_pem which is an instance method (so the
+ * input is VALUE self).
+ */
+VALUE em_ssl_x509_to_pem(X509 *x509)
+{
+	BIO *out;
+	VALUE str;
+
+	out = BIO_new(BIO_s_mem());
+	if (!out) rb_raise(rb_eRuntimeError, "%s", "EventMachine X509 cert error");
+
+	if (!PEM_write_bio_X509(out, x509)) {
+		BIO_free(out);
+		rb_raise(rb_eRuntimeError, "%s", "EventMachine X509 cert error");
+	}
+	str = em_ssl_membio2str(out);
+
+	return str;
+}

--- a/ext/em_ossl_x509store.c
+++ b/ext/em_ossl_x509store.c
@@ -1,0 +1,135 @@
+/*
+ * This file was copied and adapted from the Ruby/OpenSSL project.
+ */
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2000-2025 Ruby/OpenSSL Project Authors
+ * Copyright (C) 2025 EventMachine project authors
+ * All rights reserved.
+ */
+/*
+ * This file is licensed under the same licence as Ruby.
+ * (See the file 'COPYING-openssl'.)
+ */
+#include "em_ossl.h"
+
+/*
+ * Verify callback stuff
+ */
+static VALUE Intern_ssl_verify_peer;
+
+static VALUE em_ssl_x509stctx_new(X509_STORE_CTX *);
+
+/*
+ * Adapted from stdlib openssl's ossl_verify_cb_args
+ *
+ * NOTE: proc has been renamed to conn.  It should be an EM::Connection object.
+ */
+struct em_ssl_verify_cb_args {
+	VALUE conn;
+	VALUE preverify_ok;
+	VALUE store_ctx;
+};
+
+/* Adapted from stdlib openssl's ossl_x509stctx_new_i */
+static VALUE em_ssl_x509stctx_new_i(VALUE arg)
+{
+	return em_ssl_x509stctx_new((X509_STORE_CTX *)arg);
+}
+
+/*
+ * NOTE: This has been significantly altered from openssl's call_verify_cb_proc.
+ * It calls EM::Connection#ssl_verify_peer instead of Proc#call.
+ */
+static VALUE em_ssl_call_verify_peer(VALUE arg)
+{
+	struct em_ssl_verify_cb_args *args = (struct em_ssl_verify_cb_args *)arg;
+	if (rb_obj_method_arity(args->conn, Intern_ssl_verify_peer) == 1) {
+		// Backwards compatibility:
+		VALUE cert = rb_funcall(args->store_ctx, rb_intern("current_cert"), 0);
+		VALUE pem = rb_funcall(cert, rb_intern("to_pem"), 0);
+		return rb_funcall(args->conn, Intern_ssl_verify_peer,
+		                  1, pem);
+	} else {
+		return rb_funcall(args->conn, Intern_ssl_verify_peer,
+		                  2, args->preverify_ok, args->store_ctx);
+	}
+}
+
+/*
+ * NOTE: proc has been renamed to conn.  It should be an EM::Connection object.
+ */
+int em_ssl_verify_cb_call(VALUE conn, int ok, X509_STORE_CTX *ctx)
+{
+	VALUE rctx, ret;
+	struct em_ssl_verify_cb_args args;
+	int state;
+
+	if (NIL_P(conn))
+		return ok;
+
+	ret = Qfalse;
+	rctx = rb_protect(em_ssl_x509stctx_new_i, (VALUE)ctx, &state);
+	if (state) {
+		rb_set_errinfo(Qnil);
+		rb_warn("StoreContext initialization failure");
+	}
+	else {
+		args.conn = conn;
+		args.preverify_ok = ok ? Qtrue : Qfalse;
+		args.store_ctx = rctx;
+		ret = rb_protect(em_ssl_call_verify_peer, (VALUE)&args, &state);
+		if (state) {
+			rb_set_errinfo(Qnil);
+			rb_warn("exception in verify_peer is ignored");
+		}
+		// RTYPEDDATA_DATA(rctx) = NULL; // rctx isn't RTYPEDDATA here
+	}
+	if (ret == Qtrue) {
+		X509_STORE_CTX_set_error(ctx, X509_V_OK);
+		ok = 1;
+	}
+	else {
+		if (X509_STORE_CTX_get_error(ctx) == X509_V_OK)
+			X509_STORE_CTX_set_error(ctx, X509_V_ERR_CERT_REJECTED);
+		ok = 0;
+	}
+
+	return ok;
+}
+
+
+/*
+ * Classes
+ */
+VALUE cEmSslX509StoreContext;
+
+/*
+ * Private functions
+ */
+
+/*
+ * This has been altered significantly from ossl_x509stctx_new, in order to
+ * simply copy the data into a EM::SSL::X509::StoreContext object.
+ */
+static VALUE em_ssl_x509stctx_new(X509_STORE_CTX *ctx)
+{
+	int   error_code   = X509_STORE_CTX_get_error(ctx);
+	VALUE error        = INT2NUM(error_code);
+	VALUE error_string = rb_str_new2(X509_verify_cert_error_string(error_code));
+	VALUE error_depth  = INT2NUM(X509_STORE_CTX_get_error_depth(ctx));
+	X509 *x509         = X509_STORE_CTX_get_current_cert(ctx);
+	VALUE current_cert = em_ssl_x509_to_pem(x509);
+
+	VALUE args[4] = { current_cert, error_depth, error, error_string, };
+	return rb_class_new_instance(4, args, cEmSslX509StoreContext);
+}
+
+/*
+ * INIT
+ */
+void Init_em_ssl_x509store(void)
+{
+	Intern_ssl_verify_peer = rb_intern ("ssl_verify_peer");
+	cEmSslX509StoreContext = rb_define_class_under (mEmSslX509, "StoreContext", rb_cObject);
+}

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -253,6 +253,8 @@ else
 end
 
 # OpenSSL version checks
+Logging::message "=== Checking for OpenSSL features... ===\n"
+
 #   below are yes for 1.1.0 & later, may need to check func rather than macro
 #   with versions after 1.1.1
 have_func  "TLS_server_method"            , "openssl/ssl.h"
@@ -263,6 +265,8 @@ have_func "SSL_CTX_set_dh_auto(NULL, 0)"  , "openssl/ssl.h"
 
 # below is yes for 3.0.0 & later
 have_func "SSL_get1_peer_certificate"     , "openssl/ssl.h"
+
+Logging::message "=== Checking done. ===\n"
 
 # Hack so that try_link will test with a C++ compiler instead of a C compiler
 TRY_LINK.sub!('$(CC)', '$(CXX)')

--- a/ext/project.h
+++ b/ext/project.h
@@ -116,8 +116,7 @@ typedef int SOCKET;
 #endif
 
 #ifdef WITH_SSL
-#include <openssl/ssl.h>
-#include <openssl/err.h>
+#include "em_ossl.h"
 #endif
 
 #ifdef HAVE_EPOLL

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -57,6 +57,7 @@ Statics
 
 static VALUE EmModule;
 static VALUE EmConnection;
+
 static VALUE EmConnsHash;
 static VALUE EmTimersHash;
 
@@ -78,7 +79,6 @@ static VALUE Intern_call;
 static VALUE Intern_at;
 static VALUE Intern_receive_data;
 static VALUE Intern_ssl_handshake_completed;
-static VALUE Intern_ssl_verify_peer;
 static VALUE Intern_notify_readable;
 static VALUE Intern_notify_writable;
 static VALUE Intern_proxy_target_unbound;
@@ -110,7 +110,6 @@ static inline VALUE ensure_conn(const uintptr_t signature)
 		rb_raise (EM_eConnectionNotBound, "unknown connection: %" PRIFBSIG, signature);
 	return conn;
 }
-
 
 /****************
 t_event_callback
@@ -188,9 +187,10 @@ static inline VALUE event_callback (VALUE e_value)
 		case EM_SSL_VERIFY:
 		{
 			VALUE conn = ensure_conn(signature);
-			VALUE should_accept = rb_funcall (conn, Intern_ssl_verify_peer, 1, rb_str_new(data_str, data_num));
-			if (RTEST(should_accept))
+			X509_STORE_CTX *ctx = (X509_STORE_CTX *)data_str;
+			if (em_ssl_verify_cb_call(conn, data_num, ctx))
 				evma_accept_ssl_peer (signature);
+
 			return Qnil;
 		}
 		#endif
@@ -1479,7 +1479,6 @@ extern "C" void Init_rubyeventmachine()
 	Intern_at = rb_intern("at");
 	Intern_receive_data = rb_intern ("receive_data");
 	Intern_ssl_handshake_completed = rb_intern ("ssl_handshake_completed");
-	Intern_ssl_verify_peer = rb_intern ("ssl_verify_peer");
 	Intern_notify_readable = rb_intern ("notify_readable");
 	Intern_notify_writable = rb_intern ("notify_writable");
 	Intern_proxy_target_unbound = rb_intern ("proxy_target_unbound");
@@ -1611,6 +1610,8 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_const (EmModule, "SslVerify",                INT2NUM(EM_SSL_VERIFY                ));
 	// EM_PROXY_TARGET_UNBOUND = 110,
 	// EM_PROXY_COMPLETED = 111
+
+	Init_em_ssl();
 
 	// SSL Protocols
 	rb_define_const (EmModule, "EM_PROTO_SSLv2",   INT2NUM(EM_PROTO_SSLv2  ));

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -362,8 +362,7 @@ module EventMachine
           ctx.verify_mode |= OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
         end
         ctx.verify_callback = ->(preverify_ok, store_ctx) {
-          current_cert = store_ctx.current_cert.to_pem
-          EventMachine::event_callback selectable.uuid, SslVerify, current_cert
+          EventMachine::event_callback signature, SslVerify, [preverify_ok, store_ctx]
         }
       else
         ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/em/ssl.rb
+++ b/lib/em/ssl.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "ssl/x509/store_context"

--- a/lib/em/ssl/x509/store_context.rb
+++ b/lib/em/ssl/x509/store_context.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module EventMachine
+
+  module SSL
+    module X509
+
+      # EventMachine::SSL::X509::StoreContext wraps some of the data available
+      # from an X509_STORE_CTX object.  It is used for the second argument to
+      # Connection#verify_peer.
+      #
+      # A future release may replace this class with
+      # OpenSSL::X509::StoreContext.
+      #
+      # Compared to stdlib's OpenSSL::X509::StoreContext:
+      # * Objects of this class are always frozen.
+      # * Many methods are missing: all attribute writers,
+      #   #chain, #current_crl, and #verify.
+      #
+      # @see Connection#ssl_verify_peer
+      class StoreContext
+
+        def initialize(current_cert, error_depth, error, error_string)
+          require "openssl"
+          @current_cert = OpenSSL::X509::Certificate.new(current_cert)
+          @error = error
+          @error_depth = error_depth
+          @error_string = error_string
+          freeze
+        end
+
+        # @return [OpenSSL::X509::Certificate] the certificate in this context
+        attr_reader :current_cert
+
+        # @return [Integer] the error code of this context.
+        #
+        # See "ERROR CODES" in the X509_STORE_CTX_GET_ERROR(3SSL) man page for a
+        # full description of all error codes.
+        #
+        # @note The "error" is also used for non-errors, i.e. X509_V_OK.
+        attr_reader :error
+
+        # @return [Integer] the depth of the error
+        #
+        # This is a nonnegative integer representing where in the certificate
+        # chain the error occurred. If it is zero it occurred in the end entity
+        # certificate, one if it is the certificate which signed the end entity
+        # certificate and so on.
+        #
+        # @note The "error" depth is also used for non-errors, i.e. X509_V_OK.
+        attr_reader :error_depth
+
+        # @return [String] human readable error string for verification {error}
+        #
+        # @note The "error" string can be "ok", i.e. no error.
+        attr_reader :error_string
+
+      end
+
+    end
+  end
+end

--- a/lib/eventmachine.rb
+++ b/lib/eventmachine.rb
@@ -24,6 +24,7 @@ require 'em/buftok'
 require 'em/timers'
 require 'em/protocols'
 require 'em/connection'
+require 'em/ssl'
 require 'em/callback'
 require 'em/queue'
 require 'em/channel'
@@ -1538,7 +1539,9 @@ module EventMachine
       c.ssl_handshake_completed
     elsif opcode == SslVerify
       c = @conns[conn_binding] or raise ConnectionNotBound, "received SslVerify for unknown signature: #{conn_binding}"
-      result = c.ssl_verify_peer(data) or c.close_connection
+      result = (c.original_method(:ssl_verify_peer).arity == 1) ?
+        c.ssl_verify_peer(data[1].current_cert.to_pem) : c.ssl_verify_peer(*data)
+      c.close_connection unless result
       result
     elsif opcode == TimerFired
       t = @timers.delete( data )


### PR DESCRIPTION
This isn't complete by itself, because EM hasn't properly configured an
`X509_STORE` to go with its `SSL_CTX` and `SSL`, nor does it verify the
peer's identity (`verify_hostname` in stdlib).  Unlike stdlib, the
"store_context" is merely a read-only data structure, containing a copy
of the most useful data from the `X509_STORE_CTX`.

Also, the default implementation for `EM::Connection#ssl_verify_peer`
has been updated to log errors and returns `preverify_ok` unchanged.