### PR TITLE
Add .editorconfig for rb, cpp, h files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{cpp,h}]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
I was just using editorconfig settings that seemed sensible for what's already there.  Please change the actual values to whatever seems most suitable to you.  😄 

I suppose I *could* add "compile_commands.json" to my global gitignore... But IMO adding it here is reasonable.