### PR TITLE
CI: Add Ruby 3.1 to matrix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
-        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
         include:
           - { os: windows-2019, ruby: mingw }
         exclude:


### PR DESCRIPTION
This PR introduces Ruby 3.1, the current generally available Ruby, to the matrix.


## Current result: 1 error in tests


```
1) Error: test_https_get(TestHttpClient2): Test::Unit::TestCase::EMTestTimeout: Test was cancelled after 1 seconds.
/home/runner/work/eventmachine/eventmachine/tests/em_test_helper.rb:45:in `block (2 levels) in setup_timeout'
/home/runner/work/eventmachine/eventmachine/lib/eventmachine.rb:196:in `run_machine'
/home/runner/work/eventmachine/eventmachine/lib/eventmachine.rb:196:in `run'
/home/runner/work/eventmachine/eventmachine/tests/test_httpclient2.rb:122:in `test_https_get'
     119:   def test_https_get
     120:     omit("No SSL") unless EM.ssl?
     121:     d = nil
  => 122:     EM.run {
     123:       setup_timeout(CI_WINDOWS_OLD ? 9 : TIMEOUT)
     124:       http = silent { EM::P::HttpClient2.connect :host => 'www.google.com', :port => 443, :tls => true }
     125:       d = http.get "/"

```