### PR TITLE
Remove mention of Ruby version upper bound from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ EventMachine has been around since the early 2000s and is a mature and battle-te
 
 ## What platforms are supported by EventMachine? ##
 
-EventMachine supports Ruby 2.0.0 through 2.7, JRuby and **works well on Windows** as well
-as many operating systems from the Unix family (Linux, Mac OS X, BSD flavors).
+EventMachine supports Ruby 2.0.0 and later (see tested versions at 
+[.github/workflows/workflow.yml](.github/workflows/workflow.yml)). It runs on JRuby and **works well on Windows** 
+as well as many operating systems from the Unix family (Linux, Mac OS X, BSD flavors).
 
 
 


### PR DESCRIPTION
The README currently says:

"EventMachine supports Ruby 2.0.0 through 2.7, JRuby and **works well on Windows** as well as many operating systems from the Unix family (Linux, Mac OS X, BSD flavors)."

This PR removes the upper bound so as not to imply that Ruby 3 is not supported, and adds a note to check for tested versions if interested:

"EventMachine supports Ruby 2.0.0 and later (see tested versions at [.github/workflows/workflow.yml](.github/workflows/workflow.yml)), JRuby, and **works well on Windows**, as well as many operating systems from the Unix family (Linux, Mac OS X, BSD flavors)."

Please note that I am not very familiar with eventmachine, so please verify that my statement is correct.

As some supporting evidence, however, @robbkidd pointed out to me that:

* the gemspec does not specify an upper version bound (`s.required_ruby_version = '>= 2.0.0'`)
* the CI tests versions ranging from 2.2 to 3.1 and head