### PR TITLE
Allow EM to build with OpenSSL 3, minor CI and test fixes

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -258,6 +258,9 @@ end
 have_func  "TLS_server_method"            , "openssl/ssl.h"
 have_macro "SSL_CTX_set_min_proto_version", "openssl/ssl.h"
 
+# below exists in 1.1.0 and later, but isn't documented until 3.0.0
+have_func "SSL_CTX_set_dh_auto(NULL, 0)"  , "openssl/ssl.h"
+
 # below is yes for 3.0.0 & later
 have_func "SSL_get1_peer_certificate"     , "openssl/ssl.h"
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -258,6 +258,9 @@ end
 have_func  "TLS_server_method"            , "openssl/ssl.h"
 have_macro "SSL_CTX_set_min_proto_version", "openssl/ssl.h"
 
+# below is yes for 3.0.0 & later
+have_func "SSL_get1_peer_certificate"     , "openssl/ssl.h"
+
 # Hack so that try_link will test with a C++ compiler instead of a C compiler
 TRY_LINK.sub!('$(CC)', '$(CXX)')
 

--- a/ext/fastfilereader/rubymain.cpp
+++ b/ext/fastfilereader/rubymain.cpp
@@ -115,6 +115,9 @@ extern "C" void Init_fastfilereaderext()
 	EmModule = rb_define_module ("EventMachine");
 	FastFileReader = rb_define_class_under (EmModule, "FastFileReader", rb_cObject);
 	Mapper = rb_define_class_under (FastFileReader, "Mapper", rb_cObject);
+	// fixes lib/em/streamer.rb:70: warning: undefining the allocator of
+	// T_DATA class EventMachine::FastFileReader::Mapper
+	rb_undef_alloc_func(Mapper);
 
 	rb_define_module_function (Mapper, "new", (VALUE(*)(...))mapper_new, 1);
 	rb_define_method (Mapper, "size", (VALUE(*)(...))mapper_size, 0);

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -297,6 +297,7 @@ SslContext_t::SslContext_t (bool is_server, const std::string &privkeyfile, cons
 			if (e <= 0) ERR_print_errors_fp(stderr);
 			assert (e > 0);
 		}
+
 		if (dhparam.length() > 0) {
 			DH   *dh;
 			BIO  *bio;
@@ -321,6 +322,14 @@ SslContext_t::SslContext_t (bool is_server, const std::string &privkeyfile, cons
 
 			DH_free(dh);
 			BIO_free(bio);
+		} else {
+#ifdef HAVE_SSL_CTX_SET_DH_AUTO
+			// https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_dh_auto.html
+			// printf("\nUsing SSL_CTX_set_dh_auto\n");
+			SSL_CTX_set_dh_auto(pCtx, 1);
+#else
+			// noop
+#endif
 		}
 
 		if (ecdh_curve.length() > 0) {

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -616,7 +616,11 @@ X509 *SslBox_t::GetPeerCert()
 	X509 *cert = NULL;
 
 	if (pSSL)
+#ifdef HAVE_SSL_GET1_PEER_CERTIFICATE
+		cert = SSL_get1_peer_certificate(pSSL);
+#else
 		cert = SSL_get_peer_certificate(pSSL);
+#endif
 
 	return cert;
 }

--- a/tests/test_ssl_dhparam.rb
+++ b/tests/test_ssl_dhparam.rb
@@ -12,17 +12,22 @@ class TestSSLDhParam < Test::Unit::TestCase
   DH_1_2 =   { cipher_list: "DHE,EDH", ssl_version: %w(TLSv1_2) }
   CLIENT_1_2 = { client_unbind: true,  ssl_version: %w(TLSv1_2) }
 
-  def test_no_dhparam
+  def test_dhparam_1_2_auto
     omit_if(EM.library_type == :pure_ruby) # DH will work with defaults
     omit_if(rbx?)
 
     client_server client: CLIENT_1_2, server: DH_1_2
 
-    refute Client.handshake_completed?
-    refute Server.handshake_completed?
+    if EMSSLHandlers::IS_SSL_GE_1_1
+      assert Client.handshake_completed?
+      assert Server.handshake_completed?
+    else
+      refute Client.handshake_completed?
+      refute Server.handshake_completed?
+    end
   end
 
-  def test_dhparam_1_2
+  def test_dhparam_1_2_supplied
     omit_if(rbx?)
 
     client_server client: CLIENT_1_2, server: DH_1_2.merge(dhparam: DH_PARAM_FILE)
@@ -36,12 +41,31 @@ class TestSSLDhParam < Test::Unit::TestCase
     assert_match(/^(DHE|EDH)/, Client.cipher_name)
   end
 
-  def test_dhparam_1_3
+  def test_dhparam_1_3_supplied
     omit_if(rbx?)
     omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
 
     client = { client_unbind: true, ssl_version: %w(TLSv1_3) }
     server = { dhparam: DH_PARAM_FILE, cipher_list: "DHE,EDH", ssl_version: %w(TLSv1_3) }
+    client_server client: client, server: server
+
+    assert Client.handshake_completed?
+    assert Server.handshake_completed?
+
+    assert Client.cipher_name.length > 0
+    assert_equal Client.cipher_name, Server.cipher_name
+
+    # see https://wiki.openssl.org/index.php/TLS1.3#Ciphersuites
+    # may depend on OpenSSL build options
+    assert_equal "TLS_AES_256_GCM_SHA384", Client.cipher_name
+  end
+
+  def test_dhparam_1_3_auto
+    omit_if(rbx?)
+    omit("TLSv1_3 is unavailable") unless EM.const_defined? :EM_PROTO_TLSv1_3
+
+    client = { client_unbind: true, ssl_version: %w(TLSv1_3) }
+    server = { cipher_list: "DHE,EDH", ssl_version: %w(TLSv1_3) }
     client_server client: client, server: server
 
     assert Client.handshake_completed?


### PR DESCRIPTION
Six commits (can be squashed):

**Ruby 3+ & OpenSSL 3 fixes** - Use SSL_get1_peer_certificate with OpenSSL 3, add rb_undef_alloc_func(Mapper); for Ruby 3 warning

**Use SSL_CTX_set_dh_auto** - used when needed and available.  Updated tests/test_ssl_dhparam.rb

**Update Actions workflow** - macOS 11, windows 2022

**Test fixes/updates, add next_public_port** - some fixes are needed for windows-2022 image, updated 'find an open port' handling

**Update Actions workflow - Ubuntu 22.04, OpenSSL 3** - Add Ubuntu 22.04 Ruby 3.1 & head, both of are compiled with OpenSSL 3.0.x.  Both are passing, along with local testing.

When compiling with OpenSSL 3, there are some deprecation warnings.  Previously, OpenSSL had two API's for many crypto operations.  The older API is deprecated in OpenSSL 3.  Also, note that the only Ruby release that is compatible with OpenSSL 3 is Ruby 3.1.  But, the Ruby openssl gem release is compatible with OpenSSL 3 and works with Rubies 2.6 and later, I.think...

**More test cleanup** - minor fixes related to choosing an open port during tests