### PR TITLE
Add missing OpenSSL constants (for pure ruby implementation)

### DIFF
--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -63,6 +63,29 @@ module EventMachine
   else
     SSLConnectionWaitWritable = IO::WaitWritable
   end
+
+  if defined?(OpenSSL::OPENSSL_VERSION)
+    OPENSSL_VERSION = OpenSSL::OPENSSL_VERSION
+  else
+    OPENSSL_VERSION = "not loaded"
+  end
+  if defined?(OpenSSL::OPENSSL_LIBRARY_VERSION)
+    OPENSSL_LIBRARY_VERSION = OpenSSL::OPENSSL_LIBRARY_VERSION
+  else
+    OPENSSL_LIBRARY_VERSION = "not loaded"
+  end
+
+  openssl_version_gt = ->(maj, min, pat) {
+    if defined?(OpenSSL::OPENSSL_VERSION_NUMBER)
+      OpenSSL::OPENSSL_VERSION_NUMBER >= (maj << 28) | (min << 20) | (pat << 12)
+    else
+      false
+    end
+  }
+  # OpenSSL 1.1.0 removed support for SSLv2
+  OPENSSL_NO_SSL2 = openssl_version_gt.(1, 1, 0)
+  # OpenSSL 1.1.0 disabled support for SSLv3 (by default)
+  OPENSSL_NO_SSL3 = openssl_version_gt.(1, 1, 0)
 end
 
 module EventMachine


### PR DESCRIPTION
All of these constants are needed to even start running the pure ruby tests.

Apparently, there is no good way to test for support of protocol versions other than trying each of them.  That may be okay for tests (see the openssl gem's tests for an example), but it's too much for load-time constants.  So I'm cheating by simply checking the version numbers.  I think SSL2 may have been disabled by default prior to 1.1.0, but I wasn't able to find that in any Changelogs or documentation.  SSL3 code is still in the OpenSSL repo, but it's been disabled by default since 1.1.0.