### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
         ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', head ]
         include:
           - { os: windows-2019, ruby: mingw }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: load ruby, openssl
         uses: MSP-Greg/setup-ruby-pkgs@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ jobs:
     name: >-
       ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: ${{ (startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'windows')) && 15 || 10 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-10.15, windows-2019 ]
         ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', head ]
         include:
           - { os: windows-2019, ruby: mingw }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,12 +11,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-2019, macos-latest ]
         ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', head ]
         include:
           - { os: windows-2019, ruby: mingw }
+
+          # CRuby < 2.6 does not support macos-arm64, so these use amd64
+          - { os: macos-13, ruby: "2.2" }
+          - { os: macos-13, ruby: "2.3" }
+          - { os: macos-13, ruby: "2.4" }
+          - { os: macos-13, ruby: "2.5" }
+
         exclude:
+          - { os: macos-latest, ruby: head }
           - { os: windows-2019, ruby: head }
+
+          # CRuby < 2.6 does not support macos-arm64, so these use amd64
+          - { os: macos-latest, ruby: "2.2" }
+          - { os: macos-latest, ruby: "2.3" }
+          - { os: macos-latest, ruby: "2.4" }
+          - { os: macos-latest, ruby: "2.5" }
 
           # Avoids the following error:
           #      Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,6 +17,18 @@ jobs:
           - { os: windows-2019, ruby: mingw }
         exclude:
           - { os: windows-2019, ruby: head }
+
+          # Avoids the following error:
+          #      Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2
+          #      /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v ~> 1.0
+          #      ERROR:  While executing gem ... (RuntimeError)
+          #          Marshal.load reentered at marshal_load
+          #
+          # See https://github.com/ruby/setup-ruby/issues/496
+          #
+          # This works fine on ubuntu 20.04 and 24.04.
+          - { os: ubuntu-22.04, ruby: '2.2' }
+
     steps:
       - name: repo checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: load ruby, openssl
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+        uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           mingw: _upgrade_ openssl

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,9 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-2019, macos-latest ]
-        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', head ]
+        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head ]
         include:
-          - { os: windows-2019, ruby: mingw }
+
+          # GH-988 must be merged to support ruby >= 3.3
+          # - { os: windows-2019, ruby: mingw }
 
           # CRuby < 2.6 does not support macos-arm64, so these use amd64
           - { os: macos-13, ruby: "2.2" }
@@ -25,6 +27,10 @@ jobs:
         exclude:
           - { os: macos-latest, ruby: head }
           - { os: windows-2019, ruby: head }
+
+          # GH-988 must be merged to support ruby >= 3.3
+          - { ruby: 3.3 }
+          - { ruby: head }
 
           # CRuby < 2.6 does not support macos-arm64, so these use amd64
           - { os: macos-latest, ruby: "2.2" }

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -151,7 +151,7 @@ class Test::Unit::TestCase
   extend PlatformHelper
 
   # Tests may run slower on windows or Appveyor. YMMV
-  TIMEOUT_INTERVAL = windows? ? 0.25 : 0.25
+  TIMEOUT_INTERVAL = windows? || darwin? ? 0.50 : 0.25
 
   module EMTestCasePrepend
     def setup

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -38,7 +38,7 @@ class TestBasic < Test::Unit::TestCase
   def test_timer
     assert_nothing_raised do
       EM.run {
-        setup_timeout(darwin? ? 0.6 : 0.4)
+        setup_timeout(TIMEOUT_INTERVAL * 2)
         n = 0
         EM.add_periodic_timer(0.1) {
           n += 1
@@ -163,7 +163,7 @@ class TestBasic < Test::Unit::TestCase
     end
 
     EM.run do
-      darwin? ? setup_timeout(0.3) : setup_timeout
+      setup_timeout
       EM.start_server "127.0.0.1", @port, bound_server
       EM.bind_connect local_ip, bind_port, "127.0.0.1", @port
     end

--- a/tests/test_httpclient2.rb
+++ b/tests/test_httpclient2.rb
@@ -4,7 +4,7 @@ class TestHttpClient2 < Test::Unit::TestCase
   class TestServer < EM::Connection
   end
 
-  TIMEOUT = (windows? ? 2.0 : 1)
+  TIMEOUT = TIMEOUT_INTERVAL * 4.0
   # below may be due to an issue with OpenSSL 1.0.2 and earlier with Windows
   CI_WINDOWS_OLD = windows? and RUBY_VERSION < '2.5'
   

--- a/tests/test_idle_connection.rb
+++ b/tests/test_idle_connection.rb
@@ -25,7 +25,7 @@ class TestIdleConnection < Test::Unit::TestCase
       end
     end
 
-    assert_in_delta 0.3, a, (darwin? ? 0.2 : 0.1)
+    assert_in_delta 0.3, a, (windows? || darwin? ? 0.3 : 0.1)
     assert_in_delta 0, b, 0.1
   end
 end

--- a/tests/test_inactivity_timeout.rb
+++ b/tests/test_inactivity_timeout.rb
@@ -46,7 +46,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
         }
       }
       # Travis can vary from 0.02 to 0.17, Appveyor maybe as low as 0.01
-      assert_in_delta 0.09, (finish - start), (darwin? ? 0.10 : 0.08)
+      assert_in_delta 0.09, (finish - start), (darwin? ? 0.20 : 0.08)
 
       # simplified reproducer for comm_inactivity_timeout taking twice as long
       # as requested -- https://github.com/eventmachine/eventmachine/issues/554
@@ -87,7 +87,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
       }
 
       # .30 is double the timeout and not acceptable
-      assert_in_delta 0.15, (finish - start), (darwin? ? 0.20 : 0.14)
+      assert_in_delta 0.15, (finish - start), (darwin? ? 0.30 : 0.14)
       # make sure it was a timeout and not a TLS error
       assert_equal Errno::ETIMEDOUT, reason
     end

--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -33,7 +33,7 @@ class TestIPv4 < Test::Unit::TestCase
 
     @@received_data = nil
     @local_port = next_port
-    setup_timeout(darwin? ? 4 : 2)
+    setup_timeout(TIMEOUT_INTERVAL * 8)
 
     EM.run do
       EM::open_datagram_socket(@@public_ipv4, @local_port) do |s|

--- a/tests/test_pause.rb
+++ b/tests/test_pause.rb
@@ -48,7 +48,7 @@ class TestPause < Test::Unit::TestCase
         EM.start_server "127.0.0.1", @port, test_server
         EM.connect "127.0.0.1", @port, test_client
 
-        tmr = darwin? ? 0.10 : 0.05
+        tmr = darwin? ? 0.25 : 0.05
 
         EM.add_timer(tmr) do
           assert_equal 1, s_rx

--- a/tests/test_pure.rb
+++ b/tests/test_pure.rb
@@ -150,7 +150,7 @@ class TestPure < Test::Unit::TestCase
         EM.stop if x == 4
       end
     }
-    assert_in_delta 0.8, (finish - start), (darwin? ? 0.6 : 0.2)
+    assert_in_delta 0.8, (finish - start), TIMEOUT_INTERVAL
     assert_equal 4, x
   end
 end

--- a/tests/test_pure.rb
+++ b/tests/test_pure.rb
@@ -150,7 +150,7 @@ class TestPure < Test::Unit::TestCase
         EM.stop if x == 4
       end
     }
-    assert_in_delta 0.8, (finish - start), TIMEOUT_INTERVAL
+    assert_in_delta 0.8, (finish - start), TIMEOUT_INTERVAL * 2
     assert_equal 4, x
   end
 end

--- a/tests/test_send_file.rb
+++ b/tests/test_send_file.rb
@@ -179,7 +179,7 @@ class TestSendFile < Test::Unit::TestCase
 
       EM.run {
         EM.start_server "127.0.0.1", @port, StreamTestModule, @filename
-        setup_timeout(darwin? ? 0.5 : 0.25)
+        setup_timeout
         EM.connect "127.0.0.1", @port, TestClient do |c|
           c.data_to { |d| data << d }
         end

--- a/tests/test_threaded_resource.rb
+++ b/tests/test_threaded_resource.rb
@@ -17,7 +17,7 @@ class TestThreadedResource < Test::Unit::TestCase
 
   def test_dispatch_completion
     EM.run do
-      EM.add_timer(3) do
+      EM.add_timer(TIMEOUT_INTERVAL * 20) do
         EM.stop
         if ENV['CI'].casecmp('true').zero? and RUBY_PLATFORM[/darwin/]
           notify "Intermittent Travis MacOS: Resource dispatch timed out"


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow, and all of its jobs should pass now.

### Update the job matrix
* **Drop unsupported `ubuntu-18.04` runner from CI**
  GitHub Actions dropped support for ubuntu-18.04 on 2023-04-03:
  - https://github.com/actions/runner-images/issues/6002

  Although there are benefits to testing with older OS versions—especially given EventMachine's legacy status and the types of projects which are most likely to depend on it—there are also significant costs to maintaining CI for them once GitHub Actions has dropped support.
* **Add newer Ubuntu runners to CI**
  Each Ubuntu LTS comes with a different version of OpenSSL, Linux Kernel, etc.  And people are likely to deploy EventMachine applications to any of these versions.  So there is some benefit to testing every Ubuntu LTS release that is supported by GitHub Actions.
* **Exclude ubuntu-22.04 / ruby 2.2 from CI**
  This avoids the following error:

      Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2
      /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v ~> 1.0
      ERROR:  While executing gem ... (RuntimeError)
          Marshal.load reentered at marshal_load

  See https://github.com/ruby/setup-ruby/issues/496

  Ubuntu 20.04 and 24.04 do not have this issue.
* **Switch CI to use `macos-latest` runner**
  GitHub Actions dropped support for `macos-10.15` on 2022-12-01:
  - https://github.com/actions/runner-images/issues/5583

  Under the presumption that MacOS is primarily used for development and not for deployment, I've switched the macos GitHub Actions runners to use the "latest" release version for ruby >= 2.6.  Earlier ruby's don't support arm64, so they are using the macos-13 runner (which is amd64).

  On the one hand, this is less explicit and is no longer "pinned", so it may result in CI failing when GitHub Actions updates these runners.  On the other hand, we also won't need another PR to update these every time an old version is dropped or a new version is added.

  I attempted to make the same change from `windows-2019` to `windows-latest`.  But I saw three tests that reliably pass under windows-2019 and reliably fail under `windows-2022`.  Since I don't have a Windows OS dev env at my disposal, I'm opting to just let windows CI continue under `windows-2019`, for now.
* **Add newer ruby versions to the CI matrix**
  Ruby 3.2 should pass in CI.  However, ruby 3.3 (and head) will not pass until #988 (or something like it) is merged.  Windows mingw is likewise excluded; it builds ruby HEAD.

### Update the actions used by CI steps
* **Update `actions/checkout` to v4.**  `actions/checkout@v2` has been deprecated for some time now.
* **Update `ruby/setup-ruby-pkgs` to ruby organization.**  It looks like `ruby/setup-ruby-pkgs` contains all of the commits in `MSP-Greg/setup-ruby-pkgs`.  I'm assuming that the ruby repository is now the official version and that new updates will be pushed there.  So this switches to that repo.
### Increase various CI timeouts
* **Raise `TIMEOUT_INTERVAL` and other test timeouts for windows and macos.**  Several of these tests appeared to be flaky in CI, but only for macos or windows.  So I went through and raised many of them, for those OSes only.  In many cases, I changed the timeouts to be a multiple of TIMEOUT_INTERVAL, so that individual tests don't each need to check if they are running on `windows? || darwin?`.
* **Double test_periodic_timer timeout (in TestPure).**  This timeout was flaky in CI, so I doubled the allowed delta.
* **Increase CI job's `timeout-minutes` for windows and macos runners.**  Sometimes these jobs take 8 minutes just installing ruby and related packages, and then another 4 minutes to compile eventmachine run the test suite.