### PR TITLE
[CI] test files - fix Ruby head 'warning: literal string will be frozen...'

### DIFF
--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'em/pure_ruby' if ENV['EM_PURE_RUBY']
 require 'eventmachine'
 require 'rbconfig'

--- a/tests/test_attach.rb
+++ b/tests/test_attach.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 class TestAttach < Test::Unit::TestCase
@@ -31,7 +33,7 @@ class TestAttach < Test::Unit::TestCase
   def setup
     @port = next_port
     $read, $r, $w, $fd = nil
-    $received_data = ""
+    $received_data = "".dup
   end
 
   def teardown

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 class TestBasic < Test::Unit::TestCase
@@ -135,7 +137,7 @@ class TestBasic < Test::Unit::TestCase
 
   # From ticket #50
   def test_byte_range_send
-    $received = ''
+    $received = ''.dup
     $sent = (0..255).to_a.pack('C*')
     EM::run {
       EM::start_server "127.0.0.1", @port, BrsTestSrv

--- a/tests/test_ltp.rb
+++ b/tests/test_ltp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 class TestLineAndTextProtocol < Test::Unit::TestCase
@@ -103,7 +105,7 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
   end
 
   def test_lines_and_text
-    output = ''
+    output = ''.dup
     EM.run {
       EM.start_server( "127.0.0.1", @port, LineAndTextTest )
       setup_timeout 0.4
@@ -137,7 +139,7 @@ class TestLineAndTextProtocol < Test::Unit::TestCase
   end
 
   def test_binary_text
-    output = ''
+    output = ''.dup
     EM.run {
       EM.start_server( "127.0.0.1", @port, BinaryTextTest )
       setup_timeout 0.4

--- a/tests/test_ltp2.rb
+++ b/tests/test_ltp2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 
 # TODO!!! Need tests for overlength headers and text bodies.
@@ -51,7 +53,7 @@ class TestLineText2 < Test::Unit::TestCase
     attr_reader :lines
     def initialize *args
       super
-      @delim = "A"
+      @delim = "A".dup
       set_delimiter @delim
     end
     def receive_line line
@@ -153,7 +155,7 @@ Line 4
     def receive_binary_data data
       @n_calls ||= 0
       @n_calls += 1
-      (@body ||= "") << data
+      (@body ||= "".dup) << data
     end
   end
 

--- a/tests/test_send_file.rb
+++ b/tests/test_send_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'em_test_helper'
 require 'tempfile'
 
@@ -40,7 +42,7 @@ class TestSendFile < Test::Unit::TestCase
         f << ("A" * 5000)
       }
 
-      data = ''
+      data = ''.dup
 
       EM.run {
         EM.start_server "127.0.0.1", @port, TestModule, @filename
@@ -60,7 +62,7 @@ class TestSendFile < Test::Unit::TestCase
         f << ("A" * 1000000)
       }
 
-      data = ''
+      data = ''.dup
 
       assert_raises(RuntimeError) {
         EM.run {
@@ -102,7 +104,7 @@ class TestSendFile < Test::Unit::TestCase
         f << ("A" * 1000)
       }
 
-      data = ''
+      data = ''.dup
 
       EM.run {
         EM.start_server "127.0.0.1", @port, StreamTestModule, @filename
@@ -120,7 +122,7 @@ class TestSendFile < Test::Unit::TestCase
         f << ("A" * 1000)
       }
 
-      data = ''
+      data = ''.dup
 
       EM.run {
         EM.start_server "127.0.0.1", @port, ChunkStreamTestModule, @filename
@@ -147,7 +149,7 @@ class TestSendFile < Test::Unit::TestCase
       end
     end
     def test_stream_bad_file
-      data = ''
+      data = ''.dup
       EM.run {
         EM.start_server "127.0.0.1", @port, BadFileTestModule, @filename
         setup_timeout(5)
@@ -175,7 +177,7 @@ class TestSendFile < Test::Unit::TestCase
         f << ("A" * 10000)
       }
 
-      data = ''
+      data = ''.dup
 
       EM.run {
         EM.start_server "127.0.0.1", @port, StreamTestModule, @filename
@@ -193,7 +195,7 @@ class TestSendFile < Test::Unit::TestCase
         f << ("A" * 100000)
       }
 
-      data = ''
+      data = ''.dup
 
       EM.run {
         EM.start_server "127.0.0.1", @port, ChunkStreamTestModule, @filename


### PR DESCRIPTION
See any Ruby head CI job's logs.

Will do another PR with lib file updates for the same.