### PR TITLE
[CI] test_httpclient2.rb - fix intermittent failures on GHA

### DIFF
--- a/tests/test_httpclient2.rb
+++ b/tests/test_httpclient2.rb
@@ -88,16 +88,11 @@ class TestHttpClient2 < Test::Unit::TestCase
   def test_get_pipeline
     headers, headers2 = nil, nil
     EM.run {
-      setup_timeout TIMEOUT
+      # intermittent CI failures, external server w/two requests?
+      setup_timeout (TIMEOUT * 2)
       http = silent { EM::P::HttpClient2.connect "www.google.com", 80 }
-      d = http.get("/")
-      d.callback {
-        headers = d.headers
-      }
-      e = http.get("/")
-      e.callback {
-        headers2 = e.headers
-      }
+      http.get("/").callback { |resp| headers = resp.headers }
+      http.get("/").callback { |resp| headers2 = resp.headers }
       EM.tick_loop { EM.stop if headers && headers2 }
       EM.add_timer(1) { EM.stop }
     }


### PR DESCRIPTION
Just failed in my fork.  Friday afternoon is a busy time for GHA...

Failing test makes an external connection to google.com, and sends two requests.

In Puma, we've jumped thru hoops trying to get CI stable when the GHA runners are busy.  Most issues are blocking related.  Regardless, what never fails locally often fails intermittently on GHA.