### PR TITLE
lib files - fix Ruby head 'warning: literal string will be frozen...

### DIFF
--- a/lib/em/protocols/httpclient.rb
+++ b/lib/em/protocols/httpclient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 #
 # Author:: Francis Cianfrocca (gmail: blackhedd)
@@ -180,7 +182,7 @@ module EventMachine
           case @read_state
           when :base
             # Perform any per-request initialization here and don't consume any data.
-            @data = ""
+            @data = "".dup
             @headers = []
             @content_length = nil # not zero
             @content = ""

--- a/lib/em/protocols/line_protocol.rb
+++ b/lib/em/protocols/line_protocol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EventMachine
   module Protocols
     # LineProtocol will parse out newline terminated strings from a receive_data stream
@@ -13,7 +15,7 @@ module EventMachine
     module LineProtocol
       # @private
       def receive_data data
-        (@buf ||= '') << data
+        (@buf ||= ''.dup) << data
 
         @buf.each_line do |line|
           if line[-1] == "\n"

--- a/lib/em/protocols/object_protocol.rb
+++ b/lib/em/protocols/object_protocol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EventMachine
   module Protocols
     # ObjectProtocol allows for easy communication using marshaled ruby objects
@@ -19,7 +21,7 @@ module EventMachine
 
       # @private
       def receive_data data
-        (@buf ||= '') << data
+        (@buf ||= ''.dup) << data
 
         while @buf.size >= 4
           if @buf.size >= 4+(size=@buf.unpack('N').first)

--- a/lib/em/protocols/saslauth.rb
+++ b/lib/em/protocols/saslauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 #
 # Author:: Francis Cianfrocca (gmail: blackhedd)
@@ -84,7 +86,7 @@ module EventMachine
       MaxFieldSize = 128*1024
       def post_init
         super
-        @sasl_data = ""
+        @sasl_data = "".dup
         @sasl_values = []
       end
 
@@ -149,7 +151,7 @@ module EventMachine
       end
 
       def post_init
-        @sasl_data = ""
+        @sasl_data = "".dup
         @queries = []
       end
 


### PR DESCRIPTION
Similar to #1001, this fixes frozen string warning that are only logged with Ruby head builds.