### PR TITLE
Add str.dup to httpclient, for consistency

### DIFF
--- a/lib/em/protocols/httpclient.rb
+++ b/lib/em/protocols/httpclient.rb
@@ -91,7 +91,7 @@ module EventMachine
 
       def post_init
         @start_time = Time.now
-        @data = ""
+        @data = "".dup
         @read_state = :base
       end
 
@@ -185,7 +185,7 @@ module EventMachine
             @data = "".dup
             @headers = []
             @content_length = nil # not zero
-            @content = ""
+            @content = "".dup
             @status = nil
             @chunked = false
             @chunk_length = nil


### PR DESCRIPTION
In practice, I don't think either of these really matter:
* `@data` will just be reassigned in `#receive_data`'s `:base` clause
* `@content` should be reassigned (to non-frozen) by the earlier if/eslif clauses, prior to being mutated by the `else` clause.

But, for consistency, documentation, and in case this is subclassed, we should ensure that these vars are always mutable buffers.

This is a followup to #1003.