### PR TITLE
Run the full test suite in pure ruby CI

### DIFF
--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -242,6 +242,26 @@ module EventMachine
     def epoll
     end
 
+    # Pure ruby mode does not allow setting epoll
+    # @private
+    def epoll=(bool)
+      bool and raise Unsupported, "EM.epoll is not supported in pure_ruby mode"
+    end
+
+    # Pure ruby mode does not support epoll
+    # @private
+    def epoll?;  false end
+
+    # Pure ruby mode does not support kqueue
+    # @private
+    def kqueue?; false end
+
+    # Pure ruby mode does not allow setting kqueue
+    # @private
+    def kqueue=(bool)
+      bool and raise Unsupported, "EM.kqueue is not supported in pure_ruby mode"
+    end
+
     # @private
     def ssl?
       true

--- a/rakelib/test_pure.rake
+++ b/rakelib/test_pure.rake
@@ -7,7 +7,7 @@ end
 
 task :test_em_pure_ruby do
   ENV['EM_PURE_RUBY'] = 'true'
-  Rake::Task['test_pure'].execute
+  Rake::Task['test'].execute
 end
 
 task test_em_pure_ruby: "test:fixtures"

--- a/rakelib/test_pure.rake
+++ b/rakelib/test_pure.rake
@@ -1,10 +1,5 @@
 require 'rake/testtask'
 
-Rake::TestTask.new(:test_pure) do |t|
-  t.test_files = Dir.glob('tests/**/test_pure*.rb') + Dir.glob('tests/**/test_ssl*.rb')
-  t.warning = true
-end
-
 task :test_em_pure_ruby do
   ENV['EM_PURE_RUBY'] = 'true'
   Rake::Task['test'].execute

--- a/tests/test_attach.rb
+++ b/tests/test_attach.rb
@@ -44,6 +44,7 @@ class TestAttach < Test::Unit::TestCase
   end
 
   def test_attach
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     socket = nil
 
     EM.run {
@@ -68,6 +69,7 @@ class TestAttach < Test::Unit::TestCase
   end
 
   def test_attach_server
+    pend('FIXME: EM.attach_sd is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(jruby?)
     $before = TCPServer.new("127.0.0.1", @port)
     sig     = nil
@@ -90,6 +92,7 @@ class TestAttach < Test::Unit::TestCase
   end
 
   def test_attach_pipe
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     EM.run{
       $r, $w = IO.pipe
       EM.watch $r, PipeWatch do |c|
@@ -102,6 +105,7 @@ class TestAttach < Test::Unit::TestCase
   end
 
   def test_set_readable
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     before, after = nil
 
     EM.run{
@@ -125,6 +129,7 @@ class TestAttach < Test::Unit::TestCase
   end
 
   def test_read_write_pipe
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     result = nil
 
     pipe_reader = Module.new do
@@ -152,6 +157,7 @@ class TestAttach < Test::Unit::TestCase
 
   # This test shows that watch_only? is true for EM.watch
   def test_watch_only
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     r, w = IO.pipe
     $watch_only = nil
 
@@ -175,6 +181,7 @@ class TestAttach < Test::Unit::TestCase
 
   # This test shows that watch_only? is false for EM.attach
   def test_attach_data
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     pend("\nFIXME: Freezes Windows testing as of 2018-07-31") if windows?
     r, w = IO.pipe
     $watch_only = nil

--- a/tests/test_basic.rb
+++ b/tests/test_basic.rb
@@ -96,6 +96,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def test_unbind_error_during_stop
+    pend('FIXME: This test is broken in pure ruby mode') if pure_ruby_mode?
     assert_raises( UnbindError::ERR ) {
       EM.run {
         EM.start_server "127.0.0.1", @port
@@ -175,6 +176,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def test_invalid_address_bind_connect_dst
+    pend('FIXME: A different error is raised in pure ruby mode') if pure_ruby_mode?
     pend("\nFIXME: Windows as of 2018-06-23 on 32 bit >= 2.4 (#{RUBY_VERSION} #{RUBY_PLATFORM})") if RUBY_PLATFORM[/i386-mingw/] && RUBY_VERSION >= '2.4'
     e = nil
     EM.run do
@@ -192,6 +194,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def test_invalid_address_bind_connect_src
+    pend('FIXME: A different error is raised in pure ruby mode') if pure_ruby_mode?
     pend("\nFIXME: Windows as of 2018-06-23 on 32 bit >= 2.4 (#{RUBY_VERSION} #{RUBY_PLATFORM})") if RUBY_PLATFORM[/i386-mingw/] && RUBY_VERSION >= '2.4'
     e = nil
     EM.run do
@@ -232,6 +235,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def test_set_heartbeat_interval
+    pend('FIXME: EM.set_heartbeat_interval is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(jruby?)
     interval = 0.5
     EM.run {
@@ -275,6 +279,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def test_schedule_close
+    pend('FIXME: EM.num_close_scheduled is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(jruby?)
     localhost, port = '127.0.0.1', 9000
     timer_ran = false
@@ -297,6 +302,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def test_error_handler_idempotent # issue 185
+    pend('FIXME: EM.error_handler is broken in pure ruby mode') if pure_ruby_mode?
     errors = []
     ticks = []
     EM.error_handler do |e|

--- a/tests/test_completion.rb
+++ b/tests/test_completion.rb
@@ -7,6 +7,7 @@ class TestCompletion < Test::Unit::TestCase
   end
 
   def crank
+    pend("FIXME: pure ruby mode next_tick queue is broken for EM.stop") if pure_ruby_mode?
     # This is a slow solution, but this just executes the next tick queue
     # once. It's the easiest way for now.
     EM.run { EM.stop }
@@ -156,6 +157,7 @@ class TestCompletion < Test::Unit::TestCase
   end
 
   def test_timeout
+    pend("FIXME: This test is broken in pure ruby mode") if pure_ruby_mode?
     args = [1, 2, 3]
     EM.run do
       completion.timeout(0.0001, *args)

--- a/tests/test_connection_count.rb
+++ b/tests/test_connection_count.rb
@@ -7,6 +7,7 @@ class TestConnectionCount < Test::Unit::TestCase
   end
 
   def test_idle_connection_count
+    pend('FIXME: EM.connection_count is broken in pure ruby mode') if pure_ruby_mode?
     count = nil
     EM.run {
       count = EM.connection_count
@@ -17,6 +18,7 @@ class TestConnectionCount < Test::Unit::TestCase
 
   # Run this again with epoll enabled (if available)
   def test_idle_connection_count_epoll
+    pend('FIXME: EM.connection_count is broken in pure ruby mode') if pure_ruby_mode?
     EM.epoll if EM.epoll?
 
     count = nil
@@ -29,6 +31,7 @@ class TestConnectionCount < Test::Unit::TestCase
 
   # Run this again with kqueue enabled (if available)
   def test_idle_connection_count_kqueue
+    pend('FIXME: EM.connection_count is broken in pure ruby mode') if pure_ruby_mode?
     EM.kqueue if EM.kqueue?
 
     count = nil
@@ -47,6 +50,7 @@ class TestConnectionCount < Test::Unit::TestCase
   end
 
   def test_with_some_connections
+    pend('FIXME: EM.connection_count is broken in pure ruby mode') if pure_ruby_mode?
     EM.run {
       $client_conns = 0
       $initial_conns = EM.connection_count
@@ -72,6 +76,7 @@ class TestConnectionCount < Test::Unit::TestCase
   end
 
   def test_num_close_scheduled
+    pend('FIXME: EM.num_close_scheduled is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(jruby?)
     EM.run {
       assert_equal(0, EM.num_close_scheduled)

--- a/tests/test_connection_write.rb
+++ b/tests/test_connection_write.rb
@@ -18,6 +18,7 @@ class TestConnectionWrite < Test::Unit::TestCase
   end
 
   def test_with_naughty_callback
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     EM.run do
       r1, _ = IO.pipe
       r2, _ = IO.pipe

--- a/tests/test_deferrable.rb
+++ b/tests/test_deferrable.rb
@@ -6,6 +6,7 @@ class TestDeferrable < Test::Unit::TestCase
   end
 
   def test_timeout_without_args
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     assert_nothing_raised do
       EM.run {
         df = Later.new
@@ -17,6 +18,7 @@ class TestDeferrable < Test::Unit::TestCase
   end
 
   def test_timeout_with_args
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     args = nil
 
     EM.run {

--- a/tests/test_epoll.rb
+++ b/tests/test_epoll.rb
@@ -123,6 +123,7 @@ class TestEpoll < Test::Unit::TestCase
   end
 
   def test_attach_detach
+    pend('FIXME: EM.attach_fd is broken in pure ruby mode') if pure_ruby_mode?
     EM.epoll
     EM.run {
       EM.add_timer(0.01) { EM.stop }

--- a/tests/test_error_handler.rb
+++ b/tests/test_error_handler.rb
@@ -6,6 +6,7 @@ class TestErrorHandler < Test::Unit::TestCase
   end
 
   def test_error_handler
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     error = nil
 
     EM.error_handler{ |e|

--- a/tests/test_exc.rb
+++ b/tests/test_exc.rb
@@ -29,6 +29,7 @@ class TestSomeExceptions < Test::Unit::TestCase
   end
 
   def test_exception_on_unbind
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     assert_raises(DoomedConnectionError) {
       EM.run { EM.connect("localhost", 8888, DoomedConnection) }
     }

--- a/tests/test_file_watch.rb
+++ b/tests/test_file_watch.rb
@@ -35,6 +35,7 @@ class TestFileWatch < Test::Unit::TestCase
     end
 
     def test_events
+      pend('FIXME: EM.watch_filename is broken in pure ruby mode') if pure_ruby_mode?
       omit_if(solaris?)
       EM.run{
         file = Tempfile.new('em-watch')
@@ -59,6 +60,7 @@ class TestFileWatch < Test::Unit::TestCase
 
     # Refer: https://github.com/eventmachine/eventmachine/issues/512
     def test_invalid_signature
+      pend('FIXME: EM.watch_filename is broken in pure ruby mode') if pure_ruby_mode?
       # This works fine with kqueue, only fails with linux inotify.
       omit_if(EM.kqueue?)
 

--- a/tests/test_inactivity_timeout.rb
+++ b/tests/test_inactivity_timeout.rb
@@ -4,6 +4,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
 
   if EM.respond_to? :get_comm_inactivity_timeout
     def test_default
+      pend('FIXME: EM.get_comm_inactivity_timeout is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         c = EM.connect("127.0.0.1", 54321)
         assert_equal 0.0, c.comm_inactivity_timeout
@@ -12,6 +13,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
     end
 
     def test_set_and_get
+      pend('FIXME: EM.get_comm_inactivity_timeout is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         c = EM.connect("127.0.0.1", 54321)
         c.comm_inactivity_timeout = 2.5
@@ -21,6 +23,7 @@ class TestInactivityTimeout < Test::Unit::TestCase
     end
 
     def test_for_real
+      pend('FIXME: EM.set_heartbeat_interval is broken in pure ruby mode') if pure_ruby_mode?
       start, finish, reason = nil
 
       timeout_start = Module.new do

--- a/tests/test_io_streamer.rb
+++ b/tests/test_io_streamer.rb
@@ -36,6 +36,7 @@ class TestIOStreamer < Test::Unit::TestCase
   end
 
   def test_io_stream
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     sent = 'this is a test'
     received = ''.dup
     EM.run do

--- a/tests/test_ipv4.rb
+++ b/tests/test_ipv4.rb
@@ -54,9 +54,10 @@ class TestIPv4 < Test::Unit::TestCase
   # Try to connect via TCP to an invalid IPv4. EM.connect should raise
   # EM::ConnectionError.
   def test_tcp_connect_to_invalid_ipv4
+    pend('FIXME: pure ruby mode should raise EM::ConnectionError') if pure_ruby_mode?
     omit_if(!Test::Unit::TestCase.public_ipv4?)
     pend("\nFIXME: Windows as of 2018-06-23 on 32 bit >= 2.4 (#{RUBY_VERSION} #{RUBY_PLATFORM})") if RUBY_PLATFORM[/i386-mingw/] && RUBY_VERSION >= '2.4'
-    
+
     invalid_ipv4 = "9.9:9"
 
     EM.run do
@@ -75,6 +76,7 @@ class TestIPv4 < Test::Unit::TestCase
   # Try to send a UDP datagram to an invalid IPv4. EM.send_datagram should raise
   # EM::ConnectionError.
   def test_udp_send_datagram_to_invalid_ipv4
+    pend('FIXME: pure ruby mode should raise EM::ConnectionError') if pure_ruby_mode?
     omit_if(!Test::Unit::TestCase.public_ipv4?)
 
     invalid_ipv4 = "9.9:9"

--- a/tests/test_iterator.rb
+++ b/tests/test_iterator.rb
@@ -15,6 +15,7 @@ class TestIterator < Test::Unit::TestCase
   end
 
   def test_default_concurrency
+    pend('FIXME: EM.current_time is broken in pure ruby mode') if pure_ruby_mode?
     items = {}
     list = 1..10
     EM.run {
@@ -30,6 +31,7 @@ class TestIterator < Test::Unit::TestCase
   end
 
   def test_default_concurrency_with_a_proc
+    pend('FIXME: EM.current_time is broken in pure ruby mode') if pure_ruby_mode?
     items = {}
     list = (1..10).to_a
     original_list = list.dup
@@ -46,6 +48,7 @@ class TestIterator < Test::Unit::TestCase
   end
 
   def test_concurrency_bigger_than_list_size
+    pend('FIXME: EM.current_time is broken in pure ruby mode') if pure_ruby_mode?
     items = {}
     list = [1,2,3]
     EM.run {
@@ -61,6 +64,7 @@ class TestIterator < Test::Unit::TestCase
   end
 
   def test_changing_concurrency_affects_active_iteration
+    pend('FIXME: EM.current_time is broken in pure ruby mode') if pure_ruby_mode?
     items = {}
     list = 1..25
     seen = 0
@@ -95,6 +99,7 @@ class TestIterator < Test::Unit::TestCase
   end
 
   def test_inject
+    pend('FIXME: EM.invoke_popen is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(windows?)
 
     list = %w[ pwd uptime uname date ]

--- a/tests/test_keepalive.rb
+++ b/tests/test_keepalive.rb
@@ -11,6 +11,7 @@ class TestKeepalive < Test::Unit::TestCase
   end
 
   def test_enable_keepalive
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(!EM.respond_to?(:get_sock_opt))
 
     # I don't know why "An operation was attempted on something that is not a socket."
@@ -36,6 +37,7 @@ class TestKeepalive < Test::Unit::TestCase
   end
 
   def test_enable_keepalive_values
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(!EM.respond_to?(:get_sock_opt))
 
     # I don't know why "An operation was attempted on something that is not a socket."
@@ -88,6 +90,7 @@ class TestKeepalive < Test::Unit::TestCase
   end
 
   def test_disable_keepalive
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(!EM.respond_to?(:get_sock_opt))
 
     # I don't know why "An operation was attempted on something that is not a socket."

--- a/tests/test_pause.rb
+++ b/tests/test_pause.rb
@@ -11,6 +11,7 @@ class TestPause < Test::Unit::TestCase
     end
 
     def test_pause_resume
+      pend('FIXME: EM.pause_connection is broken in pure ruby mode') if pure_ruby_mode?
       server = nil
 
       s_rx = c_rx = 0
@@ -71,6 +72,7 @@ class TestPause < Test::Unit::TestCase
     end
 
     def test_pause_in_receive_data
+      pend('FIXME: EM.pause_connection is broken in pure ruby mode') if pure_ruby_mode?
       incoming = []
 
       test_server = Module.new do

--- a/tests/test_pending_connect_timeout.rb
+++ b/tests/test_pending_connect_timeout.rb
@@ -4,6 +4,7 @@ class TestPendingConnectTimeout < Test::Unit::TestCase
 
   if EM.respond_to? :get_pending_connect_timeout
     def test_default
+      pend('FIXME: EM.get_pending_connect_timeout is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         c = EM.connect("127.0.0.1", 54321)
         assert_equal 20.0, c.pending_connect_timeout
@@ -12,6 +13,7 @@ class TestPendingConnectTimeout < Test::Unit::TestCase
     end
 
     def test_set_and_get
+      pend('FIXME: EM.get_pending_connect_timeout is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         c = EM.connect("127.0.0.1", 54321)
         c.pending_connect_timeout = 2.5
@@ -21,6 +23,7 @@ class TestPendingConnectTimeout < Test::Unit::TestCase
     end
 
     def test_for_real
+      pend('FIXME: EM.get_pending_connect_timeout is broken in pure ruby mode') if pure_ruby_mode?
       start, finish = nil
 
       timeout_handler = Module.new do

--- a/tests/test_pool.rb
+++ b/tests/test_pool.rb
@@ -35,6 +35,7 @@ class TestPool < Test::Unit::TestCase
   end
 
   def test_reques_resources_on_error
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     pooled_res, pooled_res2 = nil
     pool.add :res
     go do
@@ -57,6 +58,7 @@ class TestPool < Test::Unit::TestCase
   end
 
   def test_supports_custom_on_error
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     eres = nil
     pool.on_error do |res|
       eres = res
@@ -82,6 +84,7 @@ class TestPool < Test::Unit::TestCase
   end
 
   def test_catches_successful_deferrables
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     performs = []
     pool.add :res
     go do
@@ -96,6 +99,7 @@ class TestPool < Test::Unit::TestCase
   end
 
   def test_prunes_locked_and_removed_resources
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     performs = []
     pool.add :res
     deferrable.succeed

--- a/tests/test_processes.rb
+++ b/tests/test_processes.rb
@@ -15,6 +15,7 @@ class TestProcesses < Test::Unit::TestCase
     # wrote to stdout.
     #
     def test_deferrable_child_process
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       ls = ""
       EM.run {
         d = EM::DeferrableChildProcess.open( "ls -ltr" )
@@ -32,6 +33,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       out, status = nil, nil
 
       EM.run{
@@ -44,6 +46,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system_bad_exitstatus
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       status = nil
       sys_pid = nil
 
@@ -57,6 +60,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system_pid
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       status = nil
       sys_pid = nil
 
@@ -71,6 +75,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system_with_proc
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       EM.run{
         EM.system('ls', proc{ |out,status| $out, $status = out, status; EM.stop })
       }
@@ -81,6 +86,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system_with_two_procs
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       EM.run{
         EM.system('sh', proc{ |process|
           process.send_data("echo hello\n")
@@ -96,6 +102,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system_cmd_arguments
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       EM.run{
         EM.system('echo', '1', '2', 'version', proc{ |process|
         }, proc{ |out,status|
@@ -109,6 +116,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_system_spaced_arguments
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       EM.run{
         EM.system('ruby', '-e', 'puts "hello"', proc{ |out,status|
           $out = out
@@ -120,6 +128,7 @@ class TestProcesses < Test::Unit::TestCase
     end
 
     def test_em_popen_pause_resume
+      pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
       c_rx = 0
 
       test_client = Module.new do

--- a/tests/test_proxy_connection.rb
+++ b/tests/test_proxy_connection.rb
@@ -126,6 +126,7 @@ class TestProxyConnection < Test::Unit::TestCase
     end
 
     def test_proxy_connection
+      pend('FIXME: EM.start_proxy is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         EM.start_server("127.0.0.1", @port, Server)
         EM.start_server("127.0.0.1", @proxy_port, ProxyServer, @port)
@@ -136,6 +137,7 @@ class TestProxyConnection < Test::Unit::TestCase
     end
 
     def test_proxied_bytes
+      pend('FIXME: EM.start_proxy is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         EM.start_server("127.0.0.1", @port, Server)
         EM.start_server("127.0.0.1", @proxy_port, ProxyServer, @port)
@@ -147,6 +149,7 @@ class TestProxyConnection < Test::Unit::TestCase
     end
 
     def test_partial_proxy_connection
+      pend('FIXME: EM.start_proxy is broken in pure ruby mode') if pure_ruby_mode?
       EM.run {
         EM.start_server("127.0.0.1", @port, Server)
         EM.start_server("127.0.0.1", @proxy_port, PartialProxyServer, @port)
@@ -159,6 +162,7 @@ class TestProxyConnection < Test::Unit::TestCase
     end
 
     def test_early_close
+      pend('FIXME: EM.start_proxy is broken in pure ruby mode') if pure_ruby_mode?
       $client_data = nil
       EM.run {
         EM.start_server("127.0.0.1", @port, Server)

--- a/tests/test_resolver.rb
+++ b/tests/test_resolver.rb
@@ -31,6 +31,7 @@ class TestResolver < Test::Unit::TestCase
   end
 
   def test_a
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     pend('FIXME: this test is broken on Windows') if windows? && RUBY_VERSION < "2.4"
 
     EM.run {
@@ -47,6 +48,7 @@ class TestResolver < Test::Unit::TestCase
   end
 
   def test_bad_host
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     EM.run {
       d = EM::DNS::Resolver.resolve "asdfasasdf"
       d.callback { assert false }
@@ -55,6 +57,7 @@ class TestResolver < Test::Unit::TestCase
   end
 
   def test_garbage
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     assert_raises( ArgumentError ) {
       EM.run {
         EM::DNS::Resolver.resolve 123
@@ -82,6 +85,7 @@ class TestResolver < Test::Unit::TestCase
 
   def test_localhost
     pend('FIXME: this test is broken on Windows') if windows?
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
 
     EM.run {
       d = EM::DNS::Resolver.resolve "localhost"
@@ -97,6 +101,7 @@ class TestResolver < Test::Unit::TestCase
   end
 
   def test_timer_cleanup
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     pend('FIXME: this test is broken on Windows') if windows? && RUBY_VERSION < "2.4"
 
     EM.run {
@@ -116,6 +121,7 @@ class TestResolver < Test::Unit::TestCase
   end
 
   def test_failure_timer_cleanup
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     EM.run {
       d = EM::DNS::Resolver.resolve "asdfasdf"
       d.callback { assert false }

--- a/tests/test_sock_opt.rb
+++ b/tests/test_sock_opt.rb
@@ -31,6 +31,7 @@ class TestSockOpt < Test::Unit::TestCase
   end
 
   def test_get_sock_opt
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(windows?)
     omit_if(!EM.respond_to?(:set_sock_opt))
 

--- a/tests/test_system.rb
+++ b/tests/test_system.rb
@@ -9,6 +9,7 @@ class TestSystem < Test::Unit::TestCase
   end
 
   def test_system
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(windows?)
 
     result = nil
@@ -25,6 +26,7 @@ class TestSystem < Test::Unit::TestCase
   end
 
   def test_system_with_string
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     omit_if(windows?)
 
     result = nil

--- a/tests/test_timers.rb
+++ b/tests/test_timers.rb
@@ -102,6 +102,7 @@ class TestTimers < Test::Unit::TestCase
   end
 
   def test_add_timer_increments_timer_count
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     EM.run {
       n = EM.get_timer_count
       EM::Timer.new(0.01) {
@@ -112,6 +113,7 @@ class TestTimers < Test::Unit::TestCase
   end
 
   def test_timer_run_decrements_timer_count
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     EM.run {
       n = EM.get_timer_count
       EM::Timer.new(0.01) {
@@ -123,28 +125,28 @@ class TestTimers < Test::Unit::TestCase
 
   # This test is only applicable to compiled versions of the reactor.
   # Pure ruby and java versions have no built-in limit on the number of outstanding timers.
-  unless [:pure_ruby, :java].include? EM.library_type
-    def test_timer_change_max_outstanding
-      defaults = EM.get_max_timers
-      EM.set_max_timers(100)
+  def test_timer_change_max_outstanding
+    omit_if jruby?
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
+    defaults = EM.get_max_timers
+    EM.set_max_timers(100)
 
-      one_hundred_one_timers = lambda do
-        101.times { EM.add_timer(0.01) {} }
-        EM.stop
-      end
-
-      assert_raises(RuntimeError) do
-        EM.run( &one_hundred_one_timers )
-      end
-
-      EM.set_max_timers( 101 )
-
-      assert_nothing_raised do
-        EM.run( &one_hundred_one_timers )
-      end
-    ensure
-      EM.set_max_timers(defaults)
+    one_hundred_one_timers = lambda do
+      101.times { EM.add_timer(0.01) {} }
+      EM.stop
     end
+
+    assert_raises(RuntimeError) do
+      EM.run( &one_hundred_one_timers )
+    end
+
+    EM.set_max_timers( 101 )
+
+    assert_nothing_raised do
+      EM.run( &one_hundred_one_timers )
+    end
+  ensure
+    EM.set_max_timers(defaults)
   end
 
 end

--- a/tests/test_unbind_reason.rb
+++ b/tests/test_unbind_reason.rb
@@ -12,6 +12,7 @@ class TestUnbindReason < Test::Unit::TestCase
 
   # RFC 5737 Address Blocks Reserved for Documentation
   def test_connect_timeout
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     conn = nil
     EM.run do
       conn = EM.connect '192.0.2.0', 80, StubConnection
@@ -22,6 +23,7 @@ class TestUnbindReason < Test::Unit::TestCase
 
   def test_connect_refused
     pend('FIXME: this test is broken on Windows') if windows?
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     conn = nil
     EM.run do
       conn = EM.connect '127.0.0.1', 12388, StubConnection
@@ -31,6 +33,7 @@ class TestUnbindReason < Test::Unit::TestCase
 
   def test_optional_argument
     pend('FIXME: this test is broken on Windows') if windows?
+    pend('FIXME: this test is broken in pure ruby mode') if pure_ruby_mode?
     conn = nil
     EM.run do
       conn = EM.connect '127.0.0.1', 12388, StubConnection


### PR DESCRIPTION
~Many of these may be trivial to implement in pure ruby mode, and some may be impossible, but for right now I'd prefer to simply have them all displayed as a "TODO list" in the test results.~

~Of course, adding these stub methods breaks many tests that were omitted based on whether or not `EM` responds to these methods.~

All of the failing tests have been marked as pending, _including the ones that failed when stub methods were added and raised EM::Unsupported_.  Where the tests failed due to an EM::Unsupported error, the name of the stubbed method has been added to the pending message.  This should simplify finding tests to un-pend, if and when pure ruby mode is fixed to support these features.

Additionally, CI for pure ruby mode has been updated to run _the entire_ test suite--albeit with 90 tests marked as pending.  This should allow us to "ratchet" pure ruby mode forward.

~The major downside~ ~A minor tradeoff of this PR is that `EM.respond_to?(method)` is no longer a reliable feature detection mechanism.  (see the comment below for an analysis of this issue)~ _This has been moved into another PR._