### PR TITLE
Use typed data for fast file reader mapper

### DIFF
--- a/ext/fastfilereader/rubymain.cpp
+++ b/ext/fastfilereader/rubymain.cpp
@@ -41,6 +41,12 @@ static void mapper_dt (void *ptr)
 		delete (Mapper_t*) ptr;
 }
 
+static const rb_data_type_t mapper_type = {
+	"EventMachine::FastFileReader::Mapper",
+	{0, mapper_dt, 0,},
+	0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 /**********
 mapper_new
 **********/
@@ -50,7 +56,7 @@ static VALUE mapper_new (VALUE self, VALUE filename)
 	Mapper_t *m = new Mapper_t (StringValueCStr (filename));
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
-	VALUE v = Data_Wrap_Struct (Mapper, 0, mapper_dt, (void*)m);
+	VALUE v = TypedData_Wrap_Struct (Mapper, &mapper_type, (void*)m);
 	return v;
 }
 
@@ -62,7 +68,7 @@ mapper_get_chunk
 static VALUE mapper_get_chunk (VALUE self, VALUE start, VALUE length)
 {
 	Mapper_t *m = NULL;
-	Data_Get_Struct (self, Mapper_t, m);
+	TypedData_Get_Struct (self, Mapper_t, &mapper_type, m);
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
 
@@ -85,7 +91,7 @@ mapper_close
 static VALUE mapper_close (VALUE self)
 {
 	Mapper_t *m = NULL;
-	Data_Get_Struct (self, Mapper_t, m);
+	TypedData_Get_Struct (self, Mapper_t, &mapper_type, m);
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
 	m->Close();
@@ -99,7 +105,7 @@ mapper_size
 static VALUE mapper_size (VALUE self)
 {
 	Mapper_t *m = NULL;
-	Data_Get_Struct (self, Mapper_t, m);
+	TypedData_Get_Struct (self, Mapper_t, &mapper_type, m);
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
 	return INT2NUM (m->GetFileSize());
@@ -124,6 +130,5 @@ extern "C" void Init_fastfilereaderext()
 	rb_define_method (Mapper, "close", (VALUE(*)(...))mapper_close, 0);
 	rb_define_method (Mapper, "get_chunk", (VALUE(*)(...))mapper_get_chunk, 2);
 }
-
 
 


### PR DESCRIPTION
The fast file reader extension still used `Data_Wrap_Struct` and `Data_Get_Struct` for `EventMachine::FastFileReader::Mapper`. Ruby 4.1-dev no longer exposes those legacy macros to this C++ extension path, so downstream Ruby-head installs fail while compiling `ext/fastfilereader/rubymain.cpp`.

This switches the mapper wrapper/accessors to Ruby typed-data APIs while keeping the same free function and object lifetime.

Verification:

- `bundle exec rake compile` with Homebrew Ruby 3.3.11 on arm64-darwin25
- `bundle exec ruby -Ilib -Itests tests/test_send_file.rb` -> 7 tests, 7 assertions
- direct `EventMachine::FastFileReader::Mapper` smoke for `size`, `get_chunk`, and `close`
- isolated fast file reader extension compile with system Ruby 2.6 headers
- `git diff --check`
- clean review-fix-loop pass

I also tried the full `bundle exec rake test` locally, but it stops before running tests while generating SSL fixtures under Ruby 3.3/OpenSSL 3.6 (`X509_REQ_set_version: passed invalid argument`). I left that out of scope because the focused fast-file-reader test path passes and the failure happens before this extension code is exercised.