### PR TITLE
Skip SSLv3 tests on OpenSSL 4.0+

### DIFF
--- a/tests/em_ssl_handlers.rb
+++ b/tests/em_ssl_handlers.rb
@@ -54,6 +54,10 @@ module EMSSLHandlers
   IS_SSL_GE_1_1 = (EM::OPENSSL_LIBRARY_VERSION[/OpenSSL (\d+\.\d+\.\d+)/, 1]
     .split('.').map(&:to_i) <=> [1,1]) == 1
 
+  # is OpenSSL version >= 4.0.0
+  IS_SSL_GE_4_0 = (EM::OPENSSL_LIBRARY_VERSION[/OpenSSL (\d+\.\d+\.\d+)/, 1]
+    .split('.').map(&:to_i) <=> [4,0]) >= 0
+
   # common start_tls parameters
   SSL_3   = { ssl_version: %w(SSLv3)   }
   TLS_1_2 = { ssl_version: %w(TLSv1_2) }

--- a/tests/test_ssl_protocols.rb
+++ b/tests/test_ssl_protocols.rb
@@ -25,7 +25,7 @@ class TestSSLProtocols < Test::Unit::TestCase
   end
 
   def test_any_to_v3
-    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3 || IS_SSL_GE_4_0
     client_server client: TLS_ALL, server: SSL_3
     assert Client.handshake_completed?
     assert Server.handshake_completed?
@@ -50,7 +50,7 @@ class TestSSLProtocols < Test::Unit::TestCase
   end
 
   def test_v3_to_any
-    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3 || IS_SSL_GE_4_0
     client_server client: SSL_3, server: TLS_ALL
     assert Client.handshake_completed?
     assert Server.handshake_completed?
@@ -66,7 +66,7 @@ class TestSSLProtocols < Test::Unit::TestCase
   end
 
   def test_v3_to_v3
-    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3 || IS_SSL_GE_4_0
     client_server client: SSL_3, server: SSL_3
     assert Client.handshake_completed?
     assert Server.handshake_completed?
@@ -136,7 +136,7 @@ class TestSSLProtocols < Test::Unit::TestCase
   end
 
   def test_v3_with_external_client
-    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3
+    omit("SSLv3 is (correctly) unavailable") if EM::OPENSSL_NO_SSL3 || IS_SSL_GE_4_0
     external_client nil, nil, :SSLv3_client, SSL_3
   end
 


### PR DESCRIPTION
SSLv3 handshake attempts fail with "no protocols available" in OpenSSL 4.0,
even when OPENSSL_NO_SSL3 is not defined at compile time. The existing
omit guard only checks the compile-time flag.

Add IS_SSL_GE_4_0 runtime version check (following the existing
IS_SSL_GE_1_1 pattern) and skip the 4 SSLv3 tests when running on
OpenSSL 4.0+.

Co-authored-by: Hermes Agent (z-ai/glm-5.2) <noreply@nousresearch.com>