### PR TITLE
Migrate fastfilereader to the TypedData API

### DIFF
--- a/ext/fastfilereader/rubymain.cpp
+++ b/ext/fastfilereader/rubymain.cpp
@@ -41,6 +41,12 @@ static void mapper_dt (void *ptr)
 		delete (Mapper_t*) ptr;
 }
 
+static const rb_data_type_t mapper_type = {
+	"EventMachine::FastFileReader::Mapper",
+	{ 0, mapper_dt, 0, },
+	0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 /**********
 mapper_new
 **********/
@@ -50,7 +56,7 @@ static VALUE mapper_new (VALUE self, VALUE filename)
 	Mapper_t *m = new Mapper_t (StringValueCStr (filename));
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
-	VALUE v = Data_Wrap_Struct (Mapper, 0, mapper_dt, (void*)m);
+	VALUE v = TypedData_Wrap_Struct (Mapper, &mapper_type, (void*)m);
 	return v;
 }
 
@@ -62,7 +68,7 @@ mapper_get_chunk
 static VALUE mapper_get_chunk (VALUE self, VALUE start, VALUE length)
 {
 	Mapper_t *m = NULL;
-	Data_Get_Struct (self, Mapper_t, m);
+	TypedData_Get_Struct (self, Mapper_t, &mapper_type, m);
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
 
@@ -85,7 +91,7 @@ mapper_close
 static VALUE mapper_close (VALUE self)
 {
 	Mapper_t *m = NULL;
-	Data_Get_Struct (self, Mapper_t, m);
+	TypedData_Get_Struct (self, Mapper_t, &mapper_type, m);
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
 	m->Close();
@@ -99,7 +105,7 @@ mapper_size
 static VALUE mapper_size (VALUE self)
 {
 	Mapper_t *m = NULL;
-	Data_Get_Struct (self, Mapper_t, m);
+	TypedData_Get_Struct (self, Mapper_t, &mapper_type, m);
 	if (!m)
 		rb_raise (rb_eStandardError, "No Mapper Object");
 	return INT2NUM (m->GetFileSize());


### PR DESCRIPTION
## Problem

Ruby master removed the long-deprecated `Data_Wrap_Struct` / `Data_Get_Struct` macros in [ruby/ruby@a26f528b3b](https://github.com/ruby/ruby/commit/a26f528b3b) ("Deprecate `struct RData` in favor of `struct RTypedData`"), so the fastfilereader extension no longer compiles against ruby-head (4.1.0dev):

```
rubymain.cpp:53:19: error: 'Data_Wrap_Struct' was not declared in this scope; did you mean 'TypedData_Wrap_Struct'?
```

This makes `gem install eventmachine` fail on ruby-head, which also breaks CI of downstream projects that bundle eventmachine — e.g. mysql2's ruby-head job: https://github.com/brianmario/mysql2/actions/runs/28774101830/job/85314025661

## Fix

Wrap `Mapper_t` with `TypedData_Wrap_Struct` / `TypedData_Get_Struct` and an `rb_data_type_t` instead. The TypedData API predates the gem's `required_ruby_version` (>= 2.5.0), so no compatibility is lost.

## Verification

- `rake compile` succeeds on ruby 4.0.5 and on ruby master (4.1.0dev, `96311d13c2`); previously the latter failed
- Full test suite on ruby master: 315 tests, 3657 assertions, 0 failures (the two `TestIPv6` errors on my machine are environmental; `test_send_file` is no longer skipped)
- `gem build` + `gem install` of the built gem succeeds on ruby master and `require "fastfilereaderext"` loads
- mysql2's spec suite (including its EventMachine specs) passes on ruby master when bundling this branch: 352 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)