### PR TITLE
Explicitly require `sorted_set` for pure_ruby mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,10 @@ gemspec
 
 gem 'rake'
 gem 'ostruct'
+gem 'sorted_set'
 
 install_if -> { RUBY_VERSION > '3.1' } do
   gem 'net-smtp'
-end
-
-# switch to install_if when ruby 2.2 support is dropped
-if RUBY_VERSION >= '3.0'
-  gem 'sorted_set'
 end
 
 group :documentation do

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -33,6 +33,7 @@ require 'forwardable'
 require 'socket'
 require 'fcntl'
 require 'set'
+require 'sorted_set'
 require 'openssl'
 
 module EventMachine


### PR DESCRIPTION
Since ruby 4.0, requiring `set` no longer autoloads `SortedSet`.

The latest version of the `sorted_set` gem is compatible with our minimum required ruby (2.5), so it should be safe to have it _unconditionally_ in the `Gemfile`.