### PR TITLE
Drop ruby 2.5 support (bump minimum ruby to 2.6.0)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-14 # arm64
+          - macos-15 # arm64
           - windows-2022
 
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
@@ -43,13 +43,13 @@ jobs:
           - { os: ubuntu-24.04, ruby: '2.6' }
           - { os: ubuntu-24.04, ruby: '2.7' }
 
-          # No EOL versions for macos-14
-          - { os: macos-14, ruby: '2.5' }
-          - { os: macos-14, ruby: '2.6' }
-          - { os: macos-14, ruby: '2.7' }
-          - { os: macos-14, ruby: '3.0' }
-          - { os: macos-14, ruby: '3.1' }
-          - { os: macos-14, ruby: '3.2' }
+          # No EOL versions for macos-15
+          - { os: macos-15, ruby: '2.5' }
+          - { os: macos-15, ruby: '2.6' }
+          - { os: macos-15, ruby: '2.7' }
+          - { os: macos-15, ruby: '3.0' }
+          - { os: macos-15, ruby: '3.1' }
+          - { os: macos-15, ruby: '3.2' }
 
           # No EOL versions for windows-2022
           - { os: windows-2022, ruby: '2.5' }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,14 +26,14 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-15 # arm64
-          - windows-2022
+          - windows-2025
 
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
 
         include:
-          - { os: windows-2022, ruby: ucrt } # used instead of "head"
+          - { os: windows-2025, ruby: ucrt } # used instead of "head"
         exclude:
-          - { os: windows-2022, ruby: head } # uses "ucrt" instead
+          - { os: windows-2025, ruby: head } # uses "ucrt" instead
 
           # Ubuntu 22.04 was released just prior to ruby 2.6's EOL
           # (no exclusions)
@@ -49,12 +49,12 @@ jobs:
           - { os: macos-15, ruby: '3.1' }
           - { os: macos-15, ruby: '3.2' }
 
-          # No EOL versions for windows-2022
-          - { os: windows-2022, ruby: '2.6' }
-          - { os: windows-2022, ruby: '2.7' }
-          - { os: windows-2022, ruby: '3.0' }
-          - { os: windows-2022, ruby: '3.1' }
-          - { os: windows-2022, ruby: '3.2' }
+          # No EOL versions for windows-2025
+          - { os: windows-2025, ruby: '2.6' }
+          - { os: windows-2025, ruby: '2.7' }
+          - { os: windows-2025, ruby: '3.0' }
+          - { os: windows-2025, ruby: '3.1' }
+          - { os: windows-2025, ruby: '3.2' }
 
     steps:
       - name: repo checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,10 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13 # amd64
           - macos-14 # arm64
           - windows-2022
 
@@ -37,9 +35,6 @@ jobs:
         exclude:
           - { os: windows-2022, ruby: head } # uses "ucrt" instead
 
-          # Ubuntu 20.04 was released just prior to ruby 2.4's EOL
-          # (no exclusions)
-
           # Ubuntu 22.04 was released just prior to ruby 2.6's EOL
           - { os: ubuntu-22.04, ruby: '2.5' }
 
@@ -47,14 +42,6 @@ jobs:
           - { os: ubuntu-24.04, ruby: '2.5' }
           - { os: ubuntu-24.04, ruby: '2.6' }
           - { os: ubuntu-24.04, ruby: '2.7' }
-
-          # No EOL versions for macos-13
-          - { os: macos-13, ruby: '2.5' }
-          - { os: macos-13, ruby: '2.6' }
-          - { os: macos-13, ruby: '2.7' }
-          - { os: macos-13, ruby: '3.0' }
-          - { os: macos-13, ruby: '3.1' }
-          - { os: macos-13, ruby: '3.2' }
 
           # No EOL versions for macos-14
           - { os: macos-14, ruby: '2.5' }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,18 +53,24 @@ jobs:
           - { os: macos-13, ruby: '2.6' }
           - { os: macos-13, ruby: '2.7' }
           - { os: macos-13, ruby: '3.0' }
+          - { os: macos-13, ruby: '3.1' }
+          - { os: macos-13, ruby: '3.2' }
 
           # No EOL versions for macos-14
           - { os: macos-14, ruby: '2.5' }
           - { os: macos-14, ruby: '2.6' }
           - { os: macos-14, ruby: '2.7' }
           - { os: macos-14, ruby: '3.0' }
+          - { os: macos-14, ruby: '3.1' }
+          - { os: macos-14, ruby: '3.2' }
 
           # No EOL versions for windows-2022
           - { os: windows-2022, ruby: '2.5' }
           - { os: windows-2022, ruby: '2.6' }
           - { os: windows-2022, ruby: '2.7' }
           - { os: windows-2022, ruby: '3.0' }
+          - { os: windows-2022, ruby: '3.1' }
+          - { os: windows-2022, ruby: '3.2' }
 
     steps:
       - name: repo checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,9 +7,9 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      # We currently support four EOL versions of ruby, but only on linux
+      # We currently support several EOL versions of ruby, but only on linux
       # versions that were released before that version of ruby went EOL.
-      min_version: 2.5
+      min_version: 2.6
 
   build:
     needs: ruby-versions
@@ -36,15 +36,13 @@ jobs:
           - { os: windows-2022, ruby: head } # uses "ucrt" instead
 
           # Ubuntu 22.04 was released just prior to ruby 2.6's EOL
-          - { os: ubuntu-22.04, ruby: '2.5' }
+          # (no exclusions)
 
           # Ubuntu 24.04 was released just prior to ruby 3.0's EOL
-          - { os: ubuntu-24.04, ruby: '2.5' }
           - { os: ubuntu-24.04, ruby: '2.6' }
           - { os: ubuntu-24.04, ruby: '2.7' }
 
           # No EOL versions for macos-15
-          - { os: macos-15, ruby: '2.5' }
           - { os: macos-15, ruby: '2.6' }
           - { os: macos-15, ruby: '2.7' }
           - { os: macos-15, ruby: '3.0' }
@@ -52,7 +50,6 @@ jobs:
           - { os: macos-15, ruby: '3.2' }
 
           # No EOL versions for windows-2022
-          - { os: windows-2022, ruby: '2.5' }
           - { os: windows-2022, ruby: '2.6' }
           - { os: windows-2022, ruby: '2.7' }
           - { os: windows-2022, ruby: '3.0' }

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,10 @@ gemspec
 
 gem 'rake'
 gem 'ostruct'
+gem 'sorted_set'
 
 install_if -> { RUBY_VERSION > '3.1' } do
   gem 'net-smtp'
-end
-
-# switch to install_if when ruby 2.2 support is dropped
-if RUBY_VERSION >= '3.0'
-  gem 'sorted_set'
 end
 
 group :documentation do

--- a/eventmachine.gemspec
+++ b/eventmachine.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version = EventMachine::VERSION
   s.homepage = 'https://github.com/eventmachine/eventmachine'
   s.licenses = ['Ruby', 'GPL-2.0']
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.authors = ["Francis Cianfrocca", "Aman Gupta"]
   s.email   = ["garbagecat10@gmail.com", "aman@tmm1.net"]

--- a/lib/em/pure_ruby.rb
+++ b/lib/em/pure_ruby.rb
@@ -33,6 +33,7 @@ require 'forwardable'
 require 'socket'
 require 'fcntl'
 require 'set'
+require 'sorted_set'
 require 'openssl'
 
 module EventMachine


### PR DESCRIPTION
As per the policies adopted in #998:
* I've dropped all EOL ruby versions from windows and macos runners.
* I've dropped all OS versions that GitHub has stopped supporting.  They simply don't run anyway.
* I've upgraded the macos and windows runners to their "latest" GA versions.
* Since GitHub dropped support for Ubuntu versions that were released prior to ruby 2.6.0, we aren't running CI against ruby 2.5.

Therefore, since we aren't running CI against ruby 2.5, we should bump the minimum required ruby version to 2.6.

Note that this PR includes #1028, so the `pure_ruby` tests also pass.
