### PR TITLE
Use TIMEOUT_INTERVAL to make some tests less flaky

### DIFF
--- a/tests/em_ssl_handlers.rb
+++ b/tests/em_ssl_handlers.rb
@@ -178,7 +178,7 @@ module EMSSLHandlers
   end
 
   def client_server(c_hndlr = Client, s_hndlr = Server,
-    client: nil, server: nil, timeout: 3.0)
+    client: nil, server: nil, timeout: 3.0 * TIMEOUT_INTERVAL)
     EM.run do
       # fail safe stop
       setup_timeout timeout

--- a/tests/em_test_helper.rb
+++ b/tests/em_test_helper.rb
@@ -164,7 +164,7 @@ class Test::Unit::TestCase
   ci_multiplier = ci?                   ? 4 : 1
   os_multiplier = (windows? || darwin?) ? 2 : 1
   rb_multiplier = pure_ruby_mode?       ? 2 : 1
-  TIMEOUT_INTERVAL = 0.25 * ci_multiplier * os_multiplier * rb_multiplier
+  ::TIMEOUT_INTERVAL = 0.25 * ci_multiplier * os_multiplier * rb_multiplier
   puts "               TIMEOUT_INTERVAL: #{TIMEOUT_INTERVAL}"
 
   module EMTestCasePrepend


### PR DESCRIPTION
The `TIMEOUT_INTERVAL` const was previously patched into `Test::Unit::TestCase` and used to give some tests a little bit longer to run, when running on Windows or Darwin, in pure_ruby mode, and in CI.

This moves `TIMEOUT_INTERVAL` to a top-level constant so it can be used by `EMSSLHandlers` (without providing an explicit `mod::CONST` path), and uses it as a multiplier for the existing timeout in `EMSSLHandlers#client_server`.